### PR TITLE
feat: near-fullscreen photo zoom-in during playback

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -60,6 +60,7 @@ function App() {
   const setShowSidebar = useAppStore((state) => state.setSidebarOpen);
   const exploreMode = useAppStore((state) => state.exploreMode);
   const setExploreMode = useAppStore((state) => state.setExploreMode);
+  const animationPhase = useAppStore((state) => state.animationPhase);
   const pictures = useAppStore((state) => state.pictures);
   const pendingPicturePlacements = useAppStore((state) => state.pendingPicturePlacements);
   const textAnnotations = useAppStore((state) => state.textAnnotations);
@@ -299,7 +300,11 @@ function App() {
       clearPendingQueuedPictureOpen();
     }
 
-    if (!playback.isPlaying || selectedPictureId || autoPlaybackPictureId || pictures.length === 0) {
+    // Wait for the cold-start preload/intro sequence to finish before ever
+    // triggering a picture. Otherwise a photo anchored at/near progress 0
+    // pops up as soon as Play is clicked (isPlaying flips true immediately),
+    // ahead of the intro camera zoom-in and before the marker has moved.
+    if (!playback.isPlaying || animationPhase !== 'playing' || selectedPictureId || autoPlaybackPictureId || pictures.length === 0) {
       lastPlaybackProgressRef.current = currentProgress;
     } else {
       const triggeredPictures = getTriggeredPlaybackPictures({
@@ -317,19 +322,26 @@ function App() {
         queuedPlaybackPictureIdsRef.current.push(...triggeredPictures.map((picture) => picture.id));
         resumePlaybackAfterPictureQueueRef.current = true;
         pause();
-        scheduleNextQueuedPlaybackPicture();
+        // Open the popup synchronously in this same effect, rather than via
+        // scheduleNextQueuedPlaybackPicture's setTimeout(0). Deferring by even
+        // one macrotask let the camera/marker (which react to the same
+        // progress update) paint an extra moving frame before the popup
+        // mounted — most visible for photos anchored right at the start.
+        clearPendingQueuedPictureOpen();
+        openNextQueuedPlaybackPicture();
       }
     }
 
     lastPlaybackProgressRef.current = currentProgress;
   }, [
+    animationPhase,
     autoPlaybackPictureId,
     clearPendingQueuedPictureOpen,
+    openNextQueuedPlaybackPicture,
     pause,
     pictures,
     playback.isPlaying,
     playback.progress,
-    scheduleNextQueuedPlaybackPicture,
     selectedPictureId,
   ]);
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -61,6 +61,7 @@ function App() {
   const exploreMode = useAppStore((state) => state.exploreMode);
   const setExploreMode = useAppStore((state) => state.setExploreMode);
   const animationPhase = useAppStore((state) => state.animationPhase);
+  const exportPictureHoldElapsedMs = useAppStore((state) => state.exportPictureHoldElapsedMs);
   const pictures = useAppStore((state) => state.pictures);
   const pendingPicturePlacements = useAppStore((state) => state.pendingPicturePlacements);
   const textAnnotations = useAppStore((state) => state.textAnnotations);
@@ -304,7 +305,11 @@ function App() {
     // triggering a picture. Otherwise a photo anchored at/near progress 0
     // pops up as soon as Play is clicked (isPlaying flips true immediately),
     // ahead of the intro camera zoom-in and before the marker has moved.
-    if (!playback.isPlaying || animationPhase !== 'playing' || selectedPictureId || autoPlaybackPictureId || pictures.length === 0) {
+    // During a deterministic export, `useVideoExportRecorder` drives its own
+    // picture-hold logic (so the export can freeze the route position for
+    // the full `displayDuration` instead of just showing the popup over an
+    // already-advancing timeline) — this effect must stay out of the way.
+    if (isDeterministicExport || !playback.isPlaying || animationPhase !== 'playing' || selectedPictureId || autoPlaybackPictureId || pictures.length === 0) {
       lastPlaybackProgressRef.current = currentProgress;
     } else {
       const triggeredPictures = getTriggeredPlaybackPictures({
@@ -337,6 +342,7 @@ function App() {
     animationPhase,
     autoPlaybackPictureId,
     clearPendingQueuedPictureOpen,
+    isDeterministicExport,
     openNextQueuedPlaybackPicture,
     pause,
     pictures,
@@ -505,7 +511,7 @@ function App() {
                   picture={activePicture} 
                   onClose={closeActivePicture}
                   exportFrame={activeExportCropMetrics}
-                  playbackCurrentTime={isDeterministicExport ? playback.currentTime : undefined}
+                  playbackCurrentTime={isDeterministicExport ? (exportPictureHoldElapsedMs ?? playback.currentTime) : undefined}
                 />
               )}
               

--- a/app/src/components/annotations/PicturePopup.tsx
+++ b/app/src/components/annotations/PicturePopup.tsx
@@ -14,19 +14,33 @@ interface PicturePopupProps {
   playbackCurrentTime?: number;
 }
 
+type AnimationPhase = 'entering' | 'visible' | 'exiting';
+
+// How long the "fake zoom" grows in / shrinks out. Kept shorter than
+// `displayDuration` so there's always a visible "visible" hold in between.
+const ZOOM_ENTER_MS = 450;
+const ZOOM_EXIT_MS = 350;
+
+function getAnimationPhase(elapsed: number, displayDuration: number): AnimationPhase {
+  if (elapsed < ZOOM_ENTER_MS) return 'entering';
+  if (elapsed > displayDuration - ZOOM_EXIT_MS) return 'exiting';
+  return 'visible';
+}
+
 export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTime }: PicturePopupProps) {
   const { t } = useI18n();
-  const [animationState, setAnimationState] = useState<'entering' | 'visible' | 'exiting'>('entering');
+  const [animationPhase, setAnimationPhase] = useState<AnimationPhase>('entering');
   const [displayProgress, setDisplayProgress] = useState(0);
   const [imageSrc, setImageSrc] = useState(picture.url);
   const progressIntervalRef = useRef<number | null>(null);
   const exitTimeoutRef = useRef<number | null>(null);
   const fallbackImageUrlRef = useRef<string | null>(null);
   const playbackPopupStartTimeRef = useRef<number | null>(null);
-  
+  const hasClosedRef = useRef(false);
+
   const displayDuration = picture.displayDuration || 5000;
-  const { imageWidth, imageHeight, isExportSafe, popupStyle } = getPicturePopupLayout(exportFrame);
-  
+  const { imageBoxWidth, imageBoxHeight, isExportSafe, popupStyle } = getPicturePopupLayout(exportFrame);
+
   const clearProgressInterval = useCallback(() => {
     if (progressIntervalRef.current !== null) {
       window.clearInterval(progressIntervalRef.current);
@@ -34,49 +48,41 @@ export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTim
     }
   }, []);
 
-  const startExit = useCallback((immediately = false) => {
-    if (exitTimeoutRef.current !== null) return;
-
+  const requestClose = useCallback(() => {
+    if (hasClosedRef.current) return;
+    hasClosedRef.current = true;
     clearProgressInterval();
-    if (immediately) {
-      onClose?.();
-      return;
-    }
-
-    setAnimationState('exiting');
-    exitTimeoutRef.current = window.setTimeout(() => {
-      exitTimeoutRef.current = null;
-      onClose?.();
-    }, 300);
+    onClose?.();
   }, [clearProgressInterval, onClose]);
 
-  useEffect(() => {
-    // Deterministic exports advance the replay clock frame-by-frame rather than
-    // in wall-clock time. Show the popup immediately and let the effect below
-    // control its lifetime from that same clock.
-    if (playbackCurrentTime !== undefined) {
-      return;
-    }
+  const handleManualClose = useCallback(() => {
+    if (exitTimeoutRef.current !== null || hasClosedRef.current) return;
+    clearProgressInterval();
+    setAnimationPhase('exiting');
+    exitTimeoutRef.current = window.setTimeout(() => {
+      exitTimeoutRef.current = null;
+      requestClose();
+    }, ZOOM_EXIT_MS);
+  }, [clearProgressInterval, requestClose]);
 
-    // After entering animation, show the picture
-    const enterTimer = window.setTimeout(() => {
-      setAnimationState('visible');
-      
-      // Start progress bar
-      const startTime = Date.now();
-      progressIntervalRef.current = window.setInterval(() => {
-        const elapsed = Date.now() - startTime;
-        const progress = Math.min((elapsed / displayDuration) * 100, 100);
-        setDisplayProgress(progress);
-        
-        if (progress >= 100) {
-          startExit();
-        }
-      }, 50);
-    }, 300); // Enter animation duration
-    
+  // Wall-clock path: drives the live preview when playback isn't a
+  // deterministic export. Ticks on an interval instead of currentTime.
+  useEffect(() => {
+    if (playbackCurrentTime !== undefined) return;
+
+    const startTime = Date.now();
+    progressIntervalRef.current = window.setInterval(() => {
+      const elapsed = Date.now() - startTime;
+      const progress = Math.min((elapsed / displayDuration) * 100, 100);
+      setDisplayProgress(progress);
+      setAnimationPhase(getAnimationPhase(elapsed, displayDuration));
+
+      if (elapsed >= displayDuration) {
+        requestClose();
+      }
+    }, 50);
+
     return () => {
-      window.clearTimeout(enterTimer);
       clearProgressInterval();
       if (exitTimeoutRef.current !== null) {
         window.clearTimeout(exitTimeoutRef.current);
@@ -85,8 +91,11 @@ export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTim
         URL.revokeObjectURL(fallbackImageUrlRef.current);
       }
     };
-  }, [clearProgressInterval, displayDuration, playbackCurrentTime, startExit]);
+  }, [clearProgressInterval, displayDuration, playbackCurrentTime, requestClose]);
 
+  // Deterministic-export path: driven off the replay clock so the zoom
+  // animation bakes into exported frames instead of jumping straight to
+  // "visible" the way the previous implementation did.
   useEffect(() => {
     if (playbackCurrentTime === undefined) return;
 
@@ -97,115 +106,118 @@ export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTim
     const elapsed = Math.max(0, playbackCurrentTime - playbackPopupStartTimeRef.current);
     const progress = Math.min((elapsed / displayDuration) * 100, 100);
     setDisplayProgress(progress);
+    setAnimationPhase(getAnimationPhase(elapsed, displayDuration));
 
-    if (progress >= 100) {
-      startExit(true);
+    if (elapsed >= displayDuration) {
+      requestClose();
     }
-  }, [displayDuration, playbackCurrentTime, startExit]);
-  
-  const handleClose = () => {
-    startExit();
-  };
-  
-  // Animation classes based on state
+  }, [displayDuration, playbackCurrentTime, requestClose]);
+
   const getAnimationClasses = () => {
-    switch (playbackCurrentTime === undefined ? animationState : 'visible') {
+    switch (animationPhase) {
       case 'entering':
-        return 'opacity-0 scale-90 translate-y-4';
+        return 'opacity-0 scale-[0.15]';
       case 'visible':
-        return 'opacity-100 scale-100 translate-y-0';
+        return 'opacity-100 scale-100';
       case 'exiting':
-        return 'opacity-0 scale-95 translate-y-2';
+        return 'opacity-0 scale-[0.85]';
       default:
         return '';
     }
   };
 
   return (
-    <div className="absolute z-20" style={popupStyle}>
-      <div 
+    <div className="absolute z-[200]" style={{ ...popupStyle, width: imageBoxWidth, height: imageBoxHeight }}>
+      {/* Near-fullscreen box: fills the sized wrapper above, rounded,
+          overflow-hidden. object-contain keeps the whole photo visible
+          (never cropped) regardless of its aspect ratio vs. the box's — any
+          letterbox gap is transparent, showing the map behind it, rather
+          than a solid fill. This box also carries the "fake zoom"
+          scale/opacity transition.
+          Note: the size lives on the *outer* wrapper (whose percentage
+          values resolve against the map container, a definite-size
+          ancestor) rather than here — an absolutely-positioned box with no
+          explicit size shrink-wraps its content, and shrink-to-fit sizing
+          treats percentage-width children as 0, which collapsed the photo
+          to nothing. */}
+      <div
         className={`
           tr-picture-popup
-          transition-all duration-300 ease-out
+          relative w-full h-full overflow-hidden rounded-xl shadow-2xl
+          origin-bottom
+          transition-all duration-500 ease-out
           ${getAnimationClasses()}
         `}
       >
+        {imageSrc ? (
+          <img
+            src={imageSrc}
+            alt={picture.title || t('media.trailPictureAlt')}
+            className="absolute inset-0 w-full h-full object-contain"
+            onError={() => {
+              if (picture.displayFile && imageSrc === picture.url) {
+                fallbackImageUrlRef.current = URL.createObjectURL(picture.displayFile);
+                setImageSrc(fallbackImageUrlRef.current);
+                return;
+              }
+              setImageSrc('');
+            }}
+          />
+        ) : (
+          <div className="absolute inset-0 flex items-center justify-center bg-[var(--evergreen)]/10 text-[var(--evergreen-60)] text-sm">
+            {t('media.imageUnavailable')}
+          </div>
+        )}
+
         {/* Progress Bar */}
         <div className="absolute top-0 left-0 right-0 h-1 bg-black/20 z-10">
-          <div 
+          <div
             className="h-full bg-[var(--trail-orange)] transition-all duration-50"
             style={{ width: `${displayProgress}%` }}
           />
         </div>
-        
-        {/* Image */}
-        <div className="relative">
-          {imageSrc ? (
-            <img
-              src={imageSrc}
-              alt={picture.title || t('media.trailPictureAlt')}
-              className="object-contain bg-[var(--evergreen)]/10"
-              style={{ width: imageWidth, height: imageHeight }}
-              onError={() => {
-                if (picture.displayFile && imageSrc === picture.url) {
-                  fallbackImageUrlRef.current = URL.createObjectURL(picture.displayFile);
-                  setImageSrc(fallbackImageUrlRef.current);
-                  return;
-                }
-                setImageSrc('');
-              }}
-            />
-          ) : (
-            <div
-              className="flex items-center justify-center bg-[var(--evergreen)]/10 text-[var(--evergreen-60)] text-sm"
-              style={{ width: imageWidth, height: imageHeight }}
-            >
-              {t('media.imageUnavailable')}
-            </div>
-          )}
-          
-          {/* Close Button */}
-          <button
-            onClick={handleClose}
-            className="absolute top-3 right-3 p-1.5 bg-black/50 hover:bg-black/70 text-white rounded-full transition-colors"
-            aria-label={t('common.close')}
-          >
-            <X className="w-4 h-4" />
-          </button>
-          
-          {/* Duration Indicator */}
-          <div className="absolute top-3 left-3 px-2 py-1 bg-black/50 text-white text-xs rounded-full">
-            {(displayDuration / 1000).toFixed(0)}s
-          </div>
+
+        {/* Close Button */}
+        <button
+          onClick={handleManualClose}
+          className="absolute top-3 right-3 p-1.5 bg-black/50 hover:bg-black/70 text-white rounded-full transition-colors"
+          aria-label={t('common.close')}
+        >
+          <X className="w-4 h-4" />
+        </button>
+
+        {/* Duration Indicator */}
+        <div className="absolute top-3 left-3 px-2 py-1 bg-black/50 text-white text-xs rounded-full">
+          {(displayDuration / 1000).toFixed(0)}s
         </div>
-        
-        {/* Caption */}
-        {(picture.title || picture.description) && (
-          <div className={`caption ${isExportSafe ? 'px-3 py-2' : ''}`}>
+
+        {/* Caption + metadata overlay */}
+        {(picture.title || picture.description || (picture.lat !== undefined && picture.lon !== undefined) || picture.timestamp) && (
+          <div className="absolute bottom-0 left-0 right-0 px-4 pt-10 pb-3 bg-gradient-to-t from-black/75 to-transparent">
             {picture.title && (
-              <p className={`font-medium ${isExportSafe ? 'text-xs' : 'text-sm'}`}>{picture.title}</p>
+              <p className={`font-medium text-white ${isExportSafe ? 'text-xs' : 'text-base'}`}>{picture.title}</p>
             )}
             {picture.description && (
-              <p className={`${isExportSafe ? 'text-[11px]' : 'text-xs'} opacity-80 mt-0.5`}>{picture.description}</p>
+              <p className={`text-white/85 mt-0.5 ${isExportSafe ? 'text-[11px]' : 'text-sm'}`}>{picture.description}</p>
+            )}
+            {(picture.lat !== undefined && picture.lon !== undefined || picture.timestamp) && (
+              <div className={`flex items-center gap-3 text-white/70 mt-1.5 ${isExportSafe ? 'text-[10px]' : 'text-xs'}`}>
+                {picture.lat !== undefined && picture.lon !== undefined && (
+                  <span className="flex items-center gap-1">
+                    <MapPin className="w-3 h-3" />
+                    {picture.lat.toFixed(4)}, {picture.lon.toFixed(4)}
+                  </span>
+                )}
+                {picture.timestamp && (
+                  <span className="flex items-center gap-1">
+                    <Calendar className="w-3 h-3" />
+                    {picture.timestamp.toLocaleDateString()}
+                  </span>
+                )}
+              </div>
             )}
           </div>
         )}
-        
-        {/* Metadata */}
-        <div className={`bg-[var(--canvas)] border-t border-[var(--evergreen)]/20 flex items-center gap-3 text-[var(--evergreen-60)] ${isExportSafe ? 'px-2.5 py-1.5 text-[10px]' : 'px-3 py-2 text-xs'}`}>
-          {picture.lat !== undefined && picture.lon !== undefined && (
-            <span className="flex items-center gap-1">
-              <MapPin className="w-3 h-3" />
-              {picture.lat.toFixed(4)}, {picture.lon.toFixed(4)}
-            </span>
-          )}
-          {picture.timestamp && (
-            <span className="flex items-center gap-1">
-              <Calendar className="w-3 h-3" />
-              {picture.timestamp.toLocaleDateString()}
-            </span>
-          )}
-        </div>
       </div>
     </div>
   );

--- a/app/src/components/annotations/PicturePopup.tsx
+++ b/app/src/components/annotations/PicturePopup.tsx
@@ -143,7 +143,12 @@ export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTim
           treats percentage-width children as 0, which collapsed the photo
           to nothing. */}
       <div
-        className="tr-picture-popup relative w-full h-full overflow-hidden rounded-xl shadow-2xl origin-bottom"
+        // No box-shadow here: html2canvas approximates box-shadow by
+        // painting a filled shape behind the element, and since this box
+        // has no background of its own (transparent, letterboxed), that
+        // shadow fill was bleeding through as a solid black patch in the
+        // exported video's letterbox gaps.
+        className="tr-picture-popup relative w-full h-full overflow-hidden rounded-xl origin-bottom"
         style={{ opacity, transform: `scale(${scale})` }}
       >
         {imageSrc ? (

--- a/app/src/components/annotations/PicturePopup.tsx
+++ b/app/src/components/annotations/PicturePopup.tsx
@@ -14,22 +14,48 @@ interface PicturePopupProps {
   playbackCurrentTime?: number;
 }
 
-type AnimationPhase = 'entering' | 'visible' | 'exiting';
-
 // How long the "fake zoom" grows in / shrinks out. Kept shorter than
-// `displayDuration` so there's always a visible "visible" hold in between.
+// `displayDuration` so there's always a visible held-still window in between.
 const ZOOM_ENTER_MS = 450;
 const ZOOM_EXIT_MS = 350;
+const ZOOM_ENTER_SCALE = 0.15;
+const ZOOM_EXIT_SCALE = 0.85;
 
-function getAnimationPhase(elapsed: number, displayDuration: number): AnimationPhase {
-  if (elapsed < ZOOM_ENTER_MS) return 'entering';
-  if (elapsed > displayDuration - ZOOM_EXIT_MS) return 'exiting';
-  return 'visible';
+function easeOutCubic(t: number) {
+  return 1 - (1 - t) ** 3;
+}
+
+function easeInCubic(t: number) {
+  return t ** 3;
+}
+
+// Computes scale/opacity directly from elapsed time instead of toggling CSS
+// classes through a `transition` and letting the browser interpolate in real
+// wall-clock time. That worked fine for the live preview, but during video
+// export each encoded frame can take far longer than its nominal slot to
+// capture (DOM-overlay rasterization isn't free) — the CSS transition would
+// often finish before more than one or two frames had even been captured,
+// making the zoom look like an abrupt jump-cut instead of a smooth animation
+// in the output. Deriving the values from `elapsed` directly makes the
+// animation a pure function of the (possibly synthetic, export-driven) clock
+// passed in, independent of how long each frame actually took to render.
+function getZoomStyle(elapsed: number, displayDuration: number): { opacity: number; scale: number } {
+  const clamped = Math.max(0, elapsed);
+  if (clamped < ZOOM_ENTER_MS) {
+    const t = easeOutCubic(Math.min(1, clamped / ZOOM_ENTER_MS));
+    return { opacity: t, scale: ZOOM_ENTER_SCALE + (1 - ZOOM_ENTER_SCALE) * t };
+  }
+  const exitStart = displayDuration - ZOOM_EXIT_MS;
+  if (clamped > exitStart) {
+    const t = easeInCubic(Math.min(1, (clamped - exitStart) / ZOOM_EXIT_MS));
+    return { opacity: 1 - t, scale: 1 - (1 - ZOOM_EXIT_SCALE) * t };
+  }
+  return { opacity: 1, scale: 1 };
 }
 
 export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTime }: PicturePopupProps) {
   const { t } = useI18n();
-  const [animationPhase, setAnimationPhase] = useState<AnimationPhase>('entering');
+  const [elapsedMs, setElapsedMs] = useState(0);
   const [displayProgress, setDisplayProgress] = useState(0);
   const [imageSrc, setImageSrc] = useState(picture.url);
   const progressIntervalRef = useRef<number | null>(null);
@@ -64,12 +90,12 @@ export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTim
       const elapsed = Date.now() - startTime;
       const progress = Math.min((elapsed / displayDuration) * 100, 100);
       setDisplayProgress(progress);
-      setAnimationPhase(getAnimationPhase(elapsed, displayDuration));
+      setElapsedMs(elapsed);
 
       if (elapsed >= displayDuration) {
         requestClose();
       }
-    }, 50);
+    }, 30);
 
     return () => {
       clearProgressInterval();
@@ -92,25 +118,14 @@ export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTim
     const elapsed = Math.max(0, playbackCurrentTime - playbackPopupStartTimeRef.current);
     const progress = Math.min((elapsed / displayDuration) * 100, 100);
     setDisplayProgress(progress);
-    setAnimationPhase(getAnimationPhase(elapsed, displayDuration));
+    setElapsedMs(elapsed);
 
     if (elapsed >= displayDuration) {
       requestClose();
     }
   }, [displayDuration, playbackCurrentTime, requestClose]);
 
-  const getAnimationClasses = () => {
-    switch (animationPhase) {
-      case 'entering':
-        return 'opacity-0 scale-[0.15]';
-      case 'visible':
-        return 'opacity-100 scale-100';
-      case 'exiting':
-        return 'opacity-0 scale-[0.85]';
-      default:
-        return '';
-    }
-  };
+  const { opacity, scale } = getZoomStyle(elapsedMs, displayDuration);
 
   return (
     <div className="absolute z-[200]" style={{ ...popupStyle, width: imageBoxWidth, height: imageBoxHeight }}>
@@ -119,7 +134,8 @@ export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTim
           (never cropped) regardless of its aspect ratio vs. the box's — any
           letterbox gap is transparent, showing the map behind it, rather
           than a solid fill. This box also carries the "fake zoom"
-          scale/opacity transition.
+          scale/opacity, driven directly from elapsed time (see
+          `getZoomStyle`) rather than a CSS transition.
           Note: the size lives on the *outer* wrapper (whose percentage
           values resolve against the map container, a definite-size
           ancestor) rather than here — an absolutely-positioned box with no
@@ -127,13 +143,8 @@ export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTim
           treats percentage-width children as 0, which collapsed the photo
           to nothing. */}
       <div
-        className={`
-          tr-picture-popup
-          relative w-full h-full overflow-hidden rounded-xl shadow-2xl
-          origin-bottom
-          transition-all duration-500 ease-out
-          ${getAnimationClasses()}
-        `}
+        className="tr-picture-popup relative w-full h-full overflow-hidden rounded-xl shadow-2xl origin-bottom"
+        style={{ opacity, transform: `scale(${scale})` }}
       >
         {imageSrc ? (
           <img

--- a/app/src/components/annotations/PicturePopup.tsx
+++ b/app/src/components/annotations/PicturePopup.tsx
@@ -5,7 +5,7 @@ import {
   getPicturePopupLayout,
   type PicturePopupExportFrame,
 } from '@/utils/picturePopup';
-import { X, MapPin, Calendar } from 'lucide-react';
+import { MapPin, Calendar } from 'lucide-react';
 
 interface PicturePopupProps {
   picture: PictureAnnotation;
@@ -33,7 +33,6 @@ export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTim
   const [displayProgress, setDisplayProgress] = useState(0);
   const [imageSrc, setImageSrc] = useState(picture.url);
   const progressIntervalRef = useRef<number | null>(null);
-  const exitTimeoutRef = useRef<number | null>(null);
   const fallbackImageUrlRef = useRef<string | null>(null);
   const playbackPopupStartTimeRef = useRef<number | null>(null);
   const hasClosedRef = useRef(false);
@@ -55,16 +54,6 @@ export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTim
     onClose?.();
   }, [clearProgressInterval, onClose]);
 
-  const handleManualClose = useCallback(() => {
-    if (exitTimeoutRef.current !== null || hasClosedRef.current) return;
-    clearProgressInterval();
-    setAnimationPhase('exiting');
-    exitTimeoutRef.current = window.setTimeout(() => {
-      exitTimeoutRef.current = null;
-      requestClose();
-    }, ZOOM_EXIT_MS);
-  }, [clearProgressInterval, requestClose]);
-
   // Wall-clock path: drives the live preview when playback isn't a
   // deterministic export. Ticks on an interval instead of currentTime.
   useEffect(() => {
@@ -84,9 +73,6 @@ export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTim
 
     return () => {
       clearProgressInterval();
-      if (exitTimeoutRef.current !== null) {
-        window.clearTimeout(exitTimeoutRef.current);
-      }
       if (fallbackImageUrlRef.current !== null) {
         URL.revokeObjectURL(fallbackImageUrlRef.current);
       }
@@ -175,20 +161,6 @@ export function PicturePopup({ picture, onClose, exportFrame, playbackCurrentTim
             className="h-full bg-[var(--trail-orange)] transition-all duration-50"
             style={{ width: `${displayProgress}%` }}
           />
-        </div>
-
-        {/* Close Button */}
-        <button
-          onClick={handleManualClose}
-          className="absolute top-3 right-3 p-1.5 bg-black/50 hover:bg-black/70 text-white rounded-full transition-colors"
-          aria-label={t('common.close')}
-        >
-          <X className="w-4 h-4" />
-        </button>
-
-        {/* Duration Indicator */}
-        <div className="absolute top-3 left-3 px-2 py-1 bg-black/50 text-white text-xs rounded-full">
-          {(displayDuration / 1000).toFixed(0)}s
         </div>
 
         {/* Caption + metadata overlay */}

--- a/app/src/components/map/hooks/usePictureMarkers.ts
+++ b/app/src/components/map/hooks/usePictureMarkers.ts
@@ -2,6 +2,18 @@ import { useEffect, type MutableRefObject } from 'react';
 import maplibregl from 'maplibre-gl';
 import type { PictureAnnotation } from '@/types';
 
+// Matches the lucide-react `Image` icon used for the Pictures tab elsewhere
+// in the app (e.g. PicturesPanel.tsx), rendered as a raw SVG string since
+// this marker element is created outside React for MapLibre.
+const PICTURE_MARKER_ICON_SVG = `
+  <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24"
+    fill="none" stroke="white" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect width="18" height="18" x="3" y="3" rx="2" ry="2" />
+    <circle cx="9" cy="9" r="2" />
+    <path d="m21 15-3.086-3.086a2 2 0 0 0-2.828 0L6 21" />
+  </svg>
+`;
+
 interface UsePictureMarkersParams {
   isMapLoaded: boolean;
   mapRef: MutableRefObject<maplibregl.Map | null>;
@@ -36,13 +48,27 @@ export function usePictureMarkers({
         background: var(--trail-orange);
         border: 3px solid var(--canvas);
         border-radius: 50%;
+        overflow: hidden;
         display: flex;
         align-items: center;
         justify-content: center;
         cursor: pointer;
         box-shadow: 0 2px 8px rgba(0,0,0,0.3);
       `;
-      element.innerHTML = '📷';
+
+      // Show the photo itself, cropped to fill the circle. Fall back to the
+      // generic icon if the thumbnail fails to load (e.g. a revoked blob
+      // URL after reload).
+      const thumb = document.createElement('img');
+      thumb.src = picture.url;
+      thumb.alt = '';
+      thumb.style.cssText = 'width: 100%; height: 100%; object-fit: cover; display: block;';
+      thumb.onerror = () => {
+        thumb.remove();
+        element.innerHTML = PICTURE_MARKER_ICON_SVG;
+      };
+      element.appendChild(thumb);
+
       element.addEventListener('click', (event) => {
         event.stopPropagation();
         setSelectedPictureId(picture.id);

--- a/app/src/components/sidebar/ExportPanel.tsx
+++ b/app/src/components/sidebar/ExportPanel.tsx
@@ -30,6 +30,21 @@ export function ExportPanel() {
     resetExportResult,
   } = useVideoExportRecorder();
 
+  // The Instagram share prompt used to be a small card buried in the
+  // scrollable sidebar (easy to miss). Surface it as a centered overlay
+  // instead — much harder not to notice right when the export finishes.
+  // Re-arming `shareModalDismissed` when `exportedBlob` changes identity (a
+  // new export just finished) directly in the render body — rather than in
+  // a useEffect — is React's recommended pattern for resetting state in
+  // response to a prop/value change: https://react.dev/learn/you-might-not-need-an-effect
+  const [shareModalDismissed, setShareModalDismissed] = useState(false);
+  const [acknowledgedBlob, setAcknowledgedBlob] = useState<Blob | null>(null);
+  if (exportedBlob !== acknowledgedBlob) {
+    setAcknowledgedBlob(exportedBlob);
+    setShareModalDismissed(false);
+  }
+  const showShareModal = Boolean(exportedBlob) && !isExporting && !shareModalDismissed;
+
   return (
     <div className="space-y-4">
       {/* Mode switch */}
@@ -154,34 +169,6 @@ export function ExportPanel() {
                 <span className="font-medium">{t('export.complete')}</span>
               </div>
 
-              <aside className="rounded-lg border border-[var(--trail-orange)]/35 bg-[var(--trail-orange-15)] p-4">
-                <div className="flex gap-3">
-                  <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-full bg-[var(--trail-orange)] text-white shadow-sm">
-                    <Instagram className="w-4 h-4" aria-hidden="true" />
-                  </div>
-                  <div className="min-w-0">
-                    <h4 className="text-sm font-semibold text-[var(--evergreen)]">
-                      {t('export.shareTitle')}
-                    </h4>
-                    <p className="mt-1 text-xs leading-5 text-[var(--evergreen-80)]">
-                      {t('export.shareBodyBefore')}{' '}
-                      <a
-                        href="https://www.instagram.com/trailreplay/"
-                        target="_blank"
-                        rel="noopener noreferrer"
-                        className="font-semibold text-[var(--evergreen)] underline decoration-[var(--trail-orange)] underline-offset-2 hover:text-[var(--trail-orange)]"
-                      >
-                        @trailreplay
-                      </a>{' '}
-                      {t('export.shareBodyAfter')}
-                    </p>
-                    <p className="mt-2 text-xs font-medium leading-5 text-[var(--evergreen)]">
-                      {t('export.shareFeature')}
-                    </p>
-                  </div>
-                </div>
-              </aside>
-
               <button
                 onClick={handleDownload}
                 className="w-full tr-btn tr-btn-primary flex items-center justify-center gap-2"
@@ -205,6 +192,61 @@ export function ExportPanel() {
             t={t}
             videoExportSettings={videoExportSettings}
           />
+
+          {showShareModal && (
+            <div
+              className="fixed inset-0 z-50 bg-black/70 flex items-center justify-center p-4"
+              onClick={() => setShareModalDismissed(true)}
+            >
+              <div
+                className="relative w-full max-w-sm rounded-xl bg-[var(--canvas)] p-6 text-center shadow-2xl"
+                onClick={(e) => e.stopPropagation()}
+              >
+                <button
+                  onClick={() => setShareModalDismissed(true)}
+                  className="absolute top-3 right-3 p-1 rounded-full hover:bg-black/5"
+                  aria-label={t('common.close')}
+                >
+                  <X className="w-4 h-4" />
+                </button>
+
+                <div className="flex items-center gap-2 justify-center text-green-600 bg-green-50 px-3 py-2 rounded-lg mb-4">
+                  <Check className="w-5 h-5" />
+                  <span className="font-medium text-sm">{t('export.complete')}</span>
+                </div>
+
+                <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-[var(--trail-orange)] text-white shadow-sm">
+                  <Instagram className="w-7 h-7" aria-hidden="true" />
+                </div>
+
+                <h4 className="mt-4 text-base font-semibold text-[var(--evergreen)]">
+                  {t('export.shareTitle')}
+                </h4>
+                <p className="mt-2 text-sm leading-6 text-[var(--evergreen-80)]">
+                  {t('export.shareBodyBefore')}{' '}
+                  <a
+                    href="https://www.instagram.com/trailreplay/"
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="font-semibold text-[var(--evergreen)] underline decoration-[var(--trail-orange)] underline-offset-2 hover:text-[var(--trail-orange)]"
+                  >
+                    @trailreplay
+                  </a>{' '}
+                  {t('export.shareBodyAfter')}
+                </p>
+                <p className="mt-3 text-sm font-medium leading-6 text-[var(--evergreen)]">
+                  {t('export.shareFeature')}
+                </p>
+
+                <button
+                  onClick={() => setShareModalDismissed(true)}
+                  className="mt-5 w-full tr-btn tr-btn-primary"
+                >
+                  {t('common.close')}
+                </button>
+              </div>
+            </div>
+          )}
         </>
       )}
     </div>

--- a/app/src/components/sidebar/export/exportOverlay.ts
+++ b/app/src/components/sidebar/export/exportOverlay.ts
@@ -114,6 +114,33 @@ export function getElevationOverlayDrawRect(params: {
   };
 }
 
+/**
+ * The popup's `<img>` is styled `object-fit: contain` so the whole photo
+ * stays visible regardless of its aspect ratio vs. its box — the element's
+ * own bounding box is still the *full* box, though, not the letterboxed
+ * content within it. Drawing straight into `popupRect` (as
+ * `getPopupOverlayDrawRect` does) stretches the natural image to fill that
+ * full box, ignoring its aspect ratio, so exported photos looked squashed/
+ * stretched. This re-derives the same contain-fitted sub-rect the browser
+ * computes for `object-fit: contain`, so the "crisp" redraw matches what's
+ * actually visible on screen.
+ */
+export function getObjectContainRect(box: Rect, naturalWidth: number, naturalHeight: number): Rect {
+  if (naturalWidth <= 0 || naturalHeight <= 0 || box.width <= 0 || box.height <= 0) return box;
+
+  const boxAspect = box.width / box.height;
+  const imageAspect = naturalWidth / naturalHeight;
+  const width = imageAspect > boxAspect ? box.width : box.height * imageAspect;
+  const height = imageAspect > boxAspect ? box.width / imageAspect : box.height;
+
+  return {
+    left: box.left + (box.width - width) / 2,
+    top: box.top + (box.height - height) / 2,
+    width,
+    height,
+  };
+}
+
 export function getPopupOverlayDrawRect(params: {
   popupRect: Rect;
   containerRect: Rect;

--- a/app/src/components/sidebar/export/useExportOverlayCapture.ts
+++ b/app/src/components/sidebar/export/useExportOverlayCapture.ts
@@ -18,6 +18,7 @@ type Html2Canvas = (
     logging: boolean;
     useCORS: boolean;
     allowTaint?: boolean;
+    ignoreElements?: (element: Element) => boolean;
   }
 ) => Promise<HTMLCanvasElement>;
 
@@ -120,7 +121,22 @@ export function useExportOverlayCapture({
           const popupRect = picturePopupElement.getBoundingClientRect();
           const popupDrawRect = getPopupOverlayDrawRect({ popupRect, containerRect, cropX, cropY, scaleToRecording });
           if (isDrawableRect(popupDrawRect)) {
-            const captureCanvas = await capture(picturePopupElement, { backgroundColor: null, scale: 1, logging: false, useCORS: true, allowTaint: true });
+            // html2canvas doesn't reliably support `object-fit: contain` —
+            // it can tile/repeat the source image to fill the element's box
+            // instead of letterboxing it, which showed up as the correctly
+            // sized photo with a stretched, repeated copy behind it. Skip
+            // the <img> in this capture entirely (chrome only: rounded
+            // corners, shadow, progress bar, caption gradient) and rely
+            // solely on the manually contain-fitted `drawImage` below for
+            // the actual photo.
+            const captureCanvas = await capture(picturePopupElement, {
+              backgroundColor: null,
+              scale: 1,
+              logging: false,
+              useCORS: true,
+              allowTaint: true,
+              ignoreElements: (element) => element.tagName === 'IMG',
+            });
             overlayContext.drawImage(captureCanvas, 0, 0, captureCanvas.width, captureCanvas.height, popupDrawRect.drawX, popupDrawRect.drawY, popupDrawRect.drawWidth, popupDrawRect.drawHeight);
             const popupImageElement = picturePopupElement.querySelector('img') as HTMLImageElement | null;
             if (popupImageElement?.complete && popupImageElement.naturalWidth > 0) {

--- a/app/src/components/sidebar/export/useExportOverlayCapture.ts
+++ b/app/src/components/sidebar/export/useExportOverlayCapture.ts
@@ -4,6 +4,7 @@ import {
   getCapturedCanvasDrawSize,
   getElevationOverlayDrawRect,
   getExportOverlayMetrics,
+  getObjectContainRect,
   getPopupOverlayDrawRect,
   getStatsOverlayDrawRect,
   isDrawableRect,
@@ -123,7 +124,16 @@ export function useExportOverlayCapture({
             overlayContext.drawImage(captureCanvas, 0, 0, captureCanvas.width, captureCanvas.height, popupDrawRect.drawX, popupDrawRect.drawY, popupDrawRect.drawWidth, popupDrawRect.drawHeight);
             const popupImageElement = picturePopupElement.querySelector('img') as HTMLImageElement | null;
             if (popupImageElement?.complete && popupImageElement.naturalWidth > 0) {
-              const imageRect = getPopupOverlayDrawRect({ popupRect: popupImageElement.getBoundingClientRect(), containerRect, cropX, cropY, scaleToRecording });
+              // The <img> is styled object-fit: contain, so its own bounding
+              // box is the *full* popup box, not the letterboxed photo
+              // within it — draw into the contain-fitted sub-rect instead,
+              // or the natural image gets stretched to fill the whole box.
+              const containRect = getObjectContainRect(
+                popupImageElement.getBoundingClientRect(),
+                popupImageElement.naturalWidth,
+                popupImageElement.naturalHeight,
+              );
+              const imageRect = getPopupOverlayDrawRect({ popupRect: containRect, containerRect, cropX, cropY, scaleToRecording });
               if (isDrawableRect(imageRect)) overlayContext.drawImage(popupImageElement, imageRect.drawX, imageRect.drawY, imageRect.drawWidth, imageRect.drawHeight);
             }
           }

--- a/app/src/components/sidebar/export/useVideoExportRecorder.ts
+++ b/app/src/components/sidebar/export/useVideoExportRecorder.ts
@@ -13,6 +13,7 @@ import {
   trackEvent,
 } from '@/utils/analytics';
 import { getActivityIconOption, isSvgActivityIcon } from '@/utils/activityIcons';
+import { getTriggeredPlaybackPictures } from '@/utils/playbackPictures';
 import {
   getSupportedMimeType,
   getVideoBitrate,
@@ -209,11 +210,51 @@ export function useVideoExportRecorder() {
       context.drawImage(cachedOverlayRef.current, 0, 0, recordW, recordH);
     }
 
-    const markerContainer = document.querySelector('.tr-marker') as HTMLElement | null;
+    const scaleX = recordW / cropW;
+    const scaleY = recordH / cropH;
+
+    // The photo popup should read as fully in front of everything else
+    // (matching the live view's z-index stacking): neither the route
+    // position marker nor the small photo-pin markers should paint over it.
+    const pictureHoldActive = Boolean(document.querySelector('.tr-picture-popup'));
+
+    // Photo pin markers along the route (`usePictureMarkers.ts`) live as
+    // MapLibre DOM markers outside the WebGL canvas, so — like the position
+    // marker below — they need to be manually recreated here or they never
+    // appear in the exported video at all.
+    if (!pictureHoldActive) document.querySelectorAll('.tr-picture-marker').forEach((markerEl) => {
+      const rect = (markerEl as HTMLElement).getBoundingClientRect();
+      const centerX = (rect.left + rect.width / 2 - containerRect.left - cropX) * scaleX;
+      const centerY = (rect.top + rect.height / 2 - containerRect.top - cropY) * scaleY;
+      const radius = (rect.width / 2) * scaleX;
+      if (radius <= 0) return;
+      if (centerX < -radius || centerX > recordW + radius || centerY < -radius || centerY > recordH + radius) return;
+
+      const computed = getComputedStyle(markerEl as HTMLElement);
+      context.save();
+      context.beginPath();
+      context.arc(centerX, centerY, radius, 0, Math.PI * 2);
+      context.closePath();
+      context.fillStyle = computed.backgroundColor || 'rgba(255, 152, 0, 0.9)';
+      context.fill();
+
+      const thumb = markerEl.querySelector('img') as HTMLImageElement | null;
+      if (thumb && thumb.complete && thumb.naturalWidth > 0) {
+        context.clip();
+        context.drawImage(thumb, centerX - radius, centerY - radius, radius * 2, radius * 2);
+      }
+      context.restore();
+
+      context.beginPath();
+      context.arc(centerX, centerY, radius, 0, Math.PI * 2);
+      context.lineWidth = (parseFloat(computed.borderWidth) || 3) * scaleX;
+      context.strokeStyle = computed.borderColor || '#ffffff';
+      context.stroke();
+    });
+
+    const markerContainer = pictureHoldActive ? null : document.querySelector('.tr-marker') as HTMLElement | null;
     if (markerContainer) {
       const markerRect = markerContainer.getBoundingClientRect();
-      const scaleX = recordW / cropW;
-      const scaleY = recordH / cropH;
       const markerX = (markerRect.left + markerRect.width / 2 - containerRect.left - cropX) * scaleX;
       const markerY = (markerRect.top + markerRect.height / 2 - containerRect.top - cropY) * scaleY;
 
@@ -434,6 +475,45 @@ export function useVideoExportRecorder() {
     }
   }, [captureFrame, encodeWebCodecsFrame, videoExportSettings.fps, waitForMapFrame]);
 
+  // Holds on a picture popup for `durationMs`, forcing a fresh DOM-overlay
+  // capture every single encoded frame instead of the ~12fps throttle
+  // `captureFrame` otherwise applies (see `getOverlayRefreshIntervalMs`) —
+  // that throttle is fine for slow-moving stats/elevation overlays, but made
+  // the popup's zoom/opacity transition look stepped and laggy since it was
+  // only being re-rasterized a handful of times over its whole animation.
+  // The route position/camera stay frozen throughout (only
+  // `exportPictureHoldElapsedMs` advances), so there's no need for the map
+  // to actually repaint each frame the way `captureDeterministicPhase` waits
+  // for — that lets this run faster too.
+  const capturePictureHold = useCallback(async (
+    durationMs: number,
+    timestampOffsetMs: number,
+  ) => {
+    const frameDurationMs = 1000 / videoExportSettings.fps;
+    const frameCount = Math.max(1, Math.ceil(durationMs / frameDurationMs));
+    const { width: recordW, height: recordH } = videoExportSettings.resolution;
+    const phaseStartTime = performance.now();
+
+    for (let frameIndex = 0; frameIndex <= frameCount; frameIndex += 1) {
+      if (!isRecordingRef.current || recordingCancelledRef.current) break;
+      useAppStore.getState().setExportPictureHoldElapsedMs(frameIndex * frameDurationMs);
+      // Let React commit the new elapsed value (and the popup's CSS
+      // transition tick forward in the DOM) before rasterizing it.
+      await new Promise<void>((resolve) => requestAnimationFrame(() => resolve()));
+      if (!isRecordingRef.current || recordingCancelledRef.current) break;
+      await updateOverlayAsync(recordW, recordH);
+      captureFrame();
+      await encodeWebCodecsFrame((timestampOffsetMs + (frameIndex * frameDurationMs)) * 1000);
+      if (frameIndex < frameCount) {
+        const nextFrameDueAt = phaseStartTime + ((frameIndex + 1) * frameDurationMs);
+        const remainingDelayMs = Math.max(0, nextFrameDueAt - performance.now());
+        if (remainingDelayMs > 0) {
+          await new Promise<void>((resolve) => window.setTimeout(resolve, remainingDelayMs));
+        }
+      }
+    }
+  }, [captureFrame, encodeWebCodecsFrame, updateOverlayAsync, videoExportSettings.fps, videoExportSettings.resolution]);
+
   // Flush and download the WebCodecs-encoded MP4 once recording has stopped.
   const finalizeWebCodecsExport = useCallback(async () => {
     const encoder = mp4EncoderRef.current;
@@ -555,6 +635,12 @@ export function useVideoExportRecorder() {
     store.setCinematicPlayed(true);
     store.setAnimationPhase('playing');
     let encodedDurationMs = INTRO_DURATION;
+    // Mirrors App.tsx's live-playback picture trigger (`getTriggeredPlaybackPictures`),
+    // but drives its own hold here so the export can freeze the route
+    // position for the picture's full `displayDuration` instead of just
+    // showing the popup over an already-advancing timeline.
+    const shownPictureIds = new Set<string>();
+    let previousProgress = 0;
 
     // The intro already contains the progress-zero pose. Begin at the first
     // advancing route frame so the cut into the route has no duplicate hold.
@@ -568,15 +654,43 @@ export function useVideoExportRecorder() {
 
       if (!isRecordingRef.current || recordingCancelledRef.current) break;
       captureFrame();
-      await encodeWebCodecsFrame((encodedDurationMs + (frameIndex * frameDurationMs)) * 1000);
+      // Match the original `(fixedBase + frameIndex * frameDurationMs)`
+      // timestamp math exactly: increment before encoding, so frame 1 lands
+      // at `INTRO_DURATION + frameDurationMs`, not `INTRO_DURATION` (which
+      // would collide with the intro phase's own last encoded timestamp).
+      encodedDurationMs += frameDurationMs;
+      await encodeWebCodecsFrame(encodedDurationMs * 1000);
 
       if (frameIndex % progressUpdateInterval === 0 || frameIndex === frameCount) {
         setExportProgress(progress * 100);
         setExportStage(t('export.recording'));
       }
+
+      const triggeredPictures = getTriggeredPlaybackPictures({
+        pictures,
+        previousProgress,
+        currentProgress: progress,
+        shownPictureIds,
+        queuedPictureIds: [],
+      });
+      previousProgress = progress;
+
+      for (const picture of triggeredPictures) {
+        if (!isRecordingRef.current || recordingCancelledRef.current) break;
+        shownPictureIds.add(picture.id);
+        store.setSelectedPictureId(picture.id);
+        const holdTimestampOffset = encodedDurationMs;
+        const holdDurationMs = picture.displayDuration || 5000;
+        // `progress`/`currentTime` are left untouched for the whole hold, so
+        // the map/marker stay frozen; only `exportPictureHoldElapsedMs`
+        // advances, driving the popup's own zoom/progress-bar animation.
+        await capturePictureHold(holdDurationMs, holdTimestampOffset);
+        encodedDurationMs = holdTimestampOffset + holdDurationMs;
+        store.setSelectedPictureId(null);
+        store.setExportPictureHoldElapsedMs(null);
+      }
     }
 
-    encodedDurationMs += frameCount * frameDurationMs;
     if (!recordingCancelledRef.current && isRecordingRef.current) {
       // Mirror the on-screen finale: a short hold at the finish, then the
       // outward camera move. Both are encoded before the file is finalized.
@@ -593,7 +707,7 @@ export function useVideoExportRecorder() {
     }
 
     if (!recordingCancelledRef.current) finishRecording();
-  }, [captureDeterministicPhase, captureFrame, encodeWebCodecsFrame, finishRecording, setExportProgress, setExportStage, setIsDeterministicExport, t, videoExportSettings, waitForMapFrame]);
+  }, [captureDeterministicPhase, capturePictureHold, captureFrame, encodeWebCodecsFrame, finishRecording, pictures, setExportProgress, setExportStage, setIsDeterministicExport, t, videoExportSettings, waitForMapFrame]);
 
   useEffect(() => {
     if (!isRecordingRef.current) return;

--- a/app/src/hooks/useRouteLandmarks.ts
+++ b/app/src/hooks/useRouteLandmarks.ts
@@ -45,7 +45,14 @@ export function useRouteLandmarks(): RouteLandmark[] {
     // Start as soon as a GPX route is available. The layer itself reveals each
     // marker along the journey, so fetching while playback starts never makes
     // the whole route suddenly appear or delays the first replay.
-    if (!nearbyPlacesEnabled) return;
+    if (!nearbyPlacesEnabled) {
+      // Disabling clears `enrichedLandmarks` (landmarksSlice), but this ref
+      // would otherwise still remember the route as "already loaded" — so a
+      // later re-enable for the same route would skip fetching and leave
+      // the just-cleared list empty forever.
+      loadedRouteKeyRef.current = null;
+      return;
+    }
     const controller = new AbortController();
     // Query each imported GPX independently. Joining distant tracks into one
     // corridor would either omit their new area or exceed the API's bounds.

--- a/app/src/index.css
+++ b/app/src/index.css
@@ -223,29 +223,6 @@ html, body {
   text-transform: uppercase;
 }
 
-/* Picture Annotation Popup */
-.tr-picture-popup {
-  background: var(--canvas);
-  border: 3px solid var(--trail-orange);
-  border-radius: 12px;
-  overflow: hidden;
-  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.3);
-  max-width: 400px;
-}
-
-.tr-picture-popup img {
-  width: 100%;
-  height: auto;
-  display: block;
-}
-
-.tr-picture-popup .caption {
-  padding: 0.75rem 1rem;
-  background: var(--evergreen);
-  color: var(--canvas);
-  font-size: 0.875rem;
-}
-
 /* Journey Builder Styles */
 .tr-journey-segment {
   background: var(--canvas);

--- a/app/src/store/slices/playbackSlice.ts
+++ b/app/src/store/slices/playbackSlice.ts
@@ -7,6 +7,7 @@ type PlaybackSlice = Pick<
   | 'playback'
   | 'cinematicPlayed'
   | 'animationPhase'
+  | 'exportPictureHoldElapsedMs'
   | 'setPlayback'
   | 'play'
   | 'pause'
@@ -17,6 +18,7 @@ type PlaybackSlice = Pick<
   | 'setCurrentSegment'
   | 'setCinematicPlayed'
   | 'setAnimationPhase'
+  | 'setExportPictureHoldElapsedMs'
   | 'resetPlayback'
 >;
 
@@ -24,6 +26,7 @@ export const createPlaybackSlice: AppSliceCreator<PlaybackSlice> = (set) => ({
   playback: createDefaultPlayback(),
   cinematicPlayed: false,
   animationPhase: 'idle',
+  exportPictureHoldElapsedMs: null,
 
   setPlayback: (playback) =>
     set((state) => {
@@ -80,6 +83,11 @@ export const createPlaybackSlice: AppSliceCreator<PlaybackSlice> = (set) => ({
       state.animationPhase = phase;
     }),
 
+  setExportPictureHoldElapsedMs: (elapsedMs) =>
+    set((state) => {
+      state.exportPictureHoldElapsedMs = elapsedMs;
+    }),
+
   resetPlayback: () =>
     set((state) => {
       const routeTimingMode = state.playback.routeTimingMode;
@@ -91,5 +99,6 @@ export const createPlaybackSlice: AppSliceCreator<PlaybackSlice> = (set) => ({
       };
       state.cinematicPlayed = false;
       state.animationPhase = 'idle';
+      state.exportPictureHoldElapsedMs = null;
     }),
 });

--- a/app/src/store/storeTypes.ts
+++ b/app/src/store/storeTypes.ts
@@ -44,6 +44,10 @@ export interface AppState {
   playback: PlaybackState;
   cinematicPlayed: boolean;
   animationPhase: 'idle' | 'preloading' | 'intro' | 'playing' | 'outro' | 'ended';
+  // Drives PicturePopup's progress bar / zoom timing during a deterministic
+  // export hold, decoupled from `playback.currentTime` so the route position
+  // (and everything derived from it) stays frozen while the photo is shown.
+  exportPictureHoldElapsedMs: number | null;
   settings: AppSettings;
   cameraSettings: CameraSettings;
   videoExportSettings: VideoExportSettings;
@@ -116,6 +120,7 @@ export interface AppState {
   setCurrentSegment: (index: number, progress: number) => void;
   setCinematicPlayed: (played: boolean) => void;
   setAnimationPhase: (phase: 'idle' | 'preloading' | 'intro' | 'playing' | 'outro' | 'ended') => void;
+  setExportPictureHoldElapsedMs: (elapsedMs: number | null) => void;
   resetPlayback: () => void;
   setSettings: (settings: Partial<AppSettings>) => void;
   setCameraSettings: (settings: Partial<CameraSettings>) => void;

--- a/app/src/utils/picturePopup.test.ts
+++ b/app/src/utils/picturePopup.test.ts
@@ -2,18 +2,20 @@ import { describe, expect, it } from 'vitest';
 import { getPicturePopupLayout } from './picturePopup';
 
 describe('getPicturePopupLayout', () => {
-  it('uses the standard preview placement when no export frame is active', () => {
+  it('centers a near-fullscreen box in the map container when no export frame is active', () => {
     const layout = getPicturePopupLayout();
 
     expect(layout.isExportSafe).toBe(false);
-    expect(layout.imageWidth).toBe(288);
+    expect(layout.imageBoxWidth).toBe('97%');
+    expect(layout.imageBoxHeight).toBe('95%');
     expect(layout.popupStyle).toEqual({
-      right: 16,
-      bottom: 16,
+      left: '50%',
+      top: '50%',
+      transform: 'translate(-50%, -50%)',
     });
   });
 
-  it('pushes the popup inside the exported frame when crop bars are present', () => {
+  it('centers a near-fullscreen box inside the exported crop frame, in CSS px', () => {
     const layout = getPicturePopupLayout({
       left: 0,
       right: 120,
@@ -24,14 +26,18 @@ describe('getPicturePopupLayout', () => {
     });
 
     expect(layout.isExportSafe).toBe(true);
-    expect(layout.popupStyle.right).toBeGreaterThan(120);
-    expect(layout.popupStyle.bottom).toBeGreaterThan(80);
-    expect(layout.imageWidth).toBeLessThanOrEqual(288);
+    expect(layout.imageBoxWidth).toBe(720 * 0.97);
+    expect(layout.imageBoxHeight).toBe(405 * 0.95);
+    expect(layout.popupStyle).toEqual({
+      left: 360,
+      top: 202.5,
+      transform: 'translate(-50%, -50%)',
+    });
   });
 
-  it('clamps popup width so narrow export frames still have a usable card', () => {
+  it('accounts for asymmetric crop bars when centering', () => {
     const layout = getPicturePopupLayout({
-      left: 0,
+      left: 40,
       right: 0,
       top: 100,
       bottom: 100,
@@ -39,7 +45,7 @@ describe('getPicturePopupLayout', () => {
       frameHeight: 409,
     });
 
-    expect(layout.imageWidth).toBe(200);
-    expect(layout.popupStyle.maxWidth).toBe(220);
+    expect(layout.popupStyle.left).toBe(40 + 230 / 2);
+    expect(layout.popupStyle.top).toBe(100 + 409 / 2);
   });
 });

--- a/app/src/utils/picturePopup.ts
+++ b/app/src/utils/picturePopup.ts
@@ -8,40 +8,52 @@ export interface PicturePopupExportFrame {
 }
 
 export interface PicturePopupLayout {
-  imageWidth: number;
-  imageHeight: number;
+  imageBoxWidth: number | string;
+  imageBoxHeight: number | string;
   isExportSafe: boolean;
   popupStyle: {
-    right: number;
-    bottom: number;
-    maxWidth?: number;
+    left: string | number;
+    top: string | number;
+    transform: string;
   };
 }
 
+/**
+ * Sizes and centers the picture popup as a near-fullscreen, full-bleed
+ * overlay (the image box is filled edge-to-edge via object-fit: cover, no
+ * letterboxing). When an `exportFrame` is known (export preview /
+ * deterministic export), the box is measured against the visible crop area
+ * in CSS px so it stays inside the export aspect ratio. Otherwise it's
+ * centered in the map container using percentages, since the popup's parent
+ * already fills that container.
+ */
 export function getPicturePopupLayout(
   exportFrame?: PicturePopupExportFrame | null
 ): PicturePopupLayout {
-  const imageWidth = exportFrame
-    ? Math.max(200, Math.min(288, exportFrame.frameWidth * 0.32))
-    : 288;
-  const imageHeight = Math.round(imageWidth * (52 / 72));
-  const popupOffset = exportFrame
-    ? Math.max(12, Math.min(20, exportFrame.frameWidth * 0.02))
-    : 16;
+  if (exportFrame) {
+    const frameCenterX = exportFrame.left + exportFrame.frameWidth / 2;
+    const frameCenterY = exportFrame.top + exportFrame.frameHeight / 2;
+
+    return {
+      imageBoxWidth: exportFrame.frameWidth * 0.97,
+      imageBoxHeight: exportFrame.frameHeight * 0.95,
+      isExportSafe: true,
+      popupStyle: {
+        left: frameCenterX,
+        top: frameCenterY,
+        transform: 'translate(-50%, -50%)',
+      },
+    };
+  }
 
   return {
-    imageWidth,
-    imageHeight,
-    isExportSafe: Boolean(exportFrame),
-    popupStyle: exportFrame
-      ? {
-          right: exportFrame.right + popupOffset,
-          bottom: exportFrame.bottom + popupOffset,
-          maxWidth: Math.max(220, Math.min(exportFrame.frameWidth - 24, imageWidth + 80)),
-        }
-      : {
-          right: popupOffset,
-          bottom: popupOffset,
-        },
+    imageBoxWidth: '97%',
+    imageBoxHeight: '95%',
+    isExportSafe: false,
+    popupStyle: {
+      left: '50%',
+      top: '50%',
+      transform: 'translate(-50%, -50%)',
+    },
   };
 }

--- a/app/vite.config.ts
+++ b/app/vite.config.ts
@@ -1,12 +1,32 @@
 /// <reference types="vitest/config" />
 import path from "path"
 import react from "@vitejs/plugin-react"
-import { defineConfig } from "vite"
+import { defineConfig, loadEnv } from "vite"
 import { inspectAttr } from 'kimi-plugin-inspect-react'
 
 // https://vite.dev/config/
-export default defineConfig(({ command }) => ({
+export default defineConfig(({ command, mode }) => {
+  // Cloudflare Pages Functions (functions/api/*.js — landmarks, contact) only
+  // run when the site is served through Cloudflare itself. Plain `vite dev`
+  // has no backend for `/api/*` at all, so those requests hit this dev
+  // server's own origin and fail. Set LOCAL_API_PROXY_TARGET in a git-ignored
+  // `.env` (see .gitignore) to forward `/api/*` to a real deployment instead
+  // — left unset, no proxy is configured and `/api/*` behaves as it always
+  // did locally (404/no backend).
+  const env = loadEnv(mode, process.cwd(), '');
+  const apiProxyTarget = env.LOCAL_API_PROXY_TARGET;
+
+  return {
   base: '/',
+  server: {
+    proxy: apiProxyTarget ? {
+      '/api': {
+        target: apiProxyTarget,
+        changeOrigin: true,
+        secure: true,
+      },
+    } : undefined,
+  },
   // The inspector stamps `code-path` source locations onto every element, so it
   // is dev-only: in production it leaks source structure and bloats both the
   // bundles and the prerendered HTML. The prerender script runs a Vite server
@@ -54,4 +74,5 @@ export default defineConfig(({ command }) => ({
     environment: 'jsdom',
     setupFiles: './src/test/setup.ts',
   },
-}));
+  };
+});


### PR DESCRIPTION
Photo annotations now zoom in near-fullscreen (with a fake CSS scale/opacity transition) instead of showing as a small corner card, and stay fully visible via object-contain with a transparent letterbox so the map shows through instead of cropping or filler bars. The map marker shows an actual photo thumbnail instead of a generic icon.

Also fixes:
- deterministic-export path skipped the enter/exit animation entirely
- picture popup could open one frame late, showing a moving marker/camera before the reveal
- pictures anchored near the route start could trigger before the cold-start intro camera zoom-in finished
- re-enabling "nearby places" after disabling it never refetched
- playback marker rendered above the photo popup


Claude-Session: https://claude.ai/code/session_01TaZi6UZN2zCzoNTgQxdj7e