### PR TITLE
fix: place photos and the elevation profile by distance in Constant Pace

### DIFF
--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -2,6 +2,7 @@ import { lazy, Suspense, useEffect, useRef, useState, useCallback, useMemo, type
 import { useAppStore } from '@/store/useAppStore';
 import { useGPX } from '@/hooks/useGPX';
 import { useUnsavedWorkGuard } from '@/hooks/useUnsavedWorkGuard';
+import { usePictureRouteSync } from '@/hooks/usePictureRouteSync';
 import { AppHeader } from '@/components/app/AppHeader';
 import { AppLoadingOverlay } from '@/components/app/AppLoadingOverlay';
 import { CropPreviewBars } from '@/components/app/CropPreviewBars';
@@ -57,6 +58,9 @@ function App() {
 
   const { parseFiles } = useGPX();
   useUnsavedWorkGuard();
+  // Keeps photo placement on the route current when the timing mode is
+  // switched after import, or when a saved project brings an older value.
+  usePictureRouteSync();
   const tracks = useAppStore((state) => state.tracks);
   const showSidebar = useAppStore((state) => state.isSidebarOpen);
   const setShowSidebar = useAppStore((state) => state.setSidebarOpen);

--- a/app/src/hooks/usePhotos.ts
+++ b/app/src/hooks/usePhotos.ts
@@ -31,7 +31,7 @@ export function usePhotos() {
     const computedJourney = buildComputedJourney(journeySegments, tracks);
 
     if (computedJourney && computedJourney.coordinates.length > 0) {
-      return projectCoordinateToJourney(computedJourney, lat, lon, playback.progress);
+      return projectCoordinateToJourney(computedJourney, lat, lon, playback.progress, playback.routeTimingMode);
     }
 
     const candidateTracks = activeTrackId
@@ -46,7 +46,7 @@ export function usePhotos() {
     }
 
     return projectCoordinateToTracks(candidateTracks, lat, lon, playback.progress);
-  }, [activeTrackId, journeySegments, playback.progress, tracks]);
+  }, [activeTrackId, journeySegments, playback.progress, playback.routeTimingMode, tracks]);
 
   const processPhoto = useCallback(async (file: File): Promise<ProcessPhotoResult> => {
     const renderableAsset = await createRenderableImageAsset(file);

--- a/app/src/hooks/usePhotos.ts
+++ b/app/src/hooks/usePhotos.ts
@@ -64,6 +64,7 @@ export function usePhotos() {
       journeySegments,
       computedJourney,
       activeTrackId,
+      routeTimingMode: playback.routeTimingMode,
     });
 
     return resolvePhotoPlacement({
@@ -78,7 +79,7 @@ export function usePhotos() {
       timestampFailureReason: timestampPlacement.reason,
       fallbackProgress: playback.progress,
     });
-  }, [activeTrackId, findPositionOnRoute, journeySegments, playback.progress, tracks]);
+  }, [activeTrackId, findPositionOnRoute, journeySegments, playback.progress, playback.routeTimingMode, tracks]);
 
   const addPhotos = useCallback(async (files: FileList | File[] | null) => {
     if (!files || files.length === 0) return;

--- a/app/src/hooks/usePictureRouteSync.ts
+++ b/app/src/hooks/usePictureRouteSync.ts
@@ -1,0 +1,69 @@
+import { useEffect } from 'react';
+import { useAppStore } from '@/store/useAppStore';
+import { buildComputedJourney } from '@/utils/journeyUtils';
+import { projectCoordinateToJourney } from '@/utils/routeProjection';
+
+/**
+ * Haelt die Einordnung der Fotos auf der Strecke aktuell.
+ *
+ * Die Stelle eines Fotos wurde bisher nur einmal beim Einfuegen berechnet -
+ * mit dem Massstab, der gerade eingestellt war. Wer die Fotos einfuegt und
+ * ERST DANACH auf Constant Pace umschaltet, behielt deshalb die alte, nach
+ * Messpunkten gezaehlte Stelle: Das Foto erschien im Video deutlich hinter
+ * der Stelle, an der es aufgenommen wurde. Dasselbe galt fuer geladene
+ * Projektdateien, die den alten Wert mitbringen.
+ *
+ * Wichtig fuer die Ausloeser unten: Der Durchlauf haengt bewusst NICHT an
+ * der Fotoliste selbst, sondern nur an Anzahl, Strecke und Massstab. Sonst
+ * wuerde jede geschriebene Stelle den Effekt erneut ausloesen - und auf
+ * einer Hin-und-Rueckstrecke, wo Hin- und Rueckweg uebereinanderliegen,
+ * koennte die Zuordnung zwischen beiden Aesten hin- und herspringen und
+ * die Oberflaeche endlos neu rechnen. So laeuft je Aenderung genau ein
+ * Durchgang. Waehrend eines Exports bleibt er ganz aus.
+ *
+ * Von Hand gesetzte Fotos werden nie angetastet.
+ */
+const TOLERANCE = 1e-6;
+
+export function usePictureRouteSync() {
+  const tracks = useAppStore((state) => state.tracks);
+  const journeySegments = useAppStore((state) => state.journeySegments);
+  const routeTimingMode = useAppStore((state) => state.playback.routeTimingMode);
+  const pictureCount = useAppStore((state) => state.pictures.length);
+  const isExporting = useAppStore((state) => state.isExporting);
+
+  useEffect(() => {
+    if (isExporting || pictureCount === 0) {
+      return;
+    }
+
+    const store = useAppStore.getState();
+    const computedJourney = buildComputedJourney(store.journeySegments, store.tracks);
+    if (!computedJourney || computedJourney.coordinates.length === 0) {
+      return;
+    }
+
+    for (const picture of store.pictures) {
+      if (picture.placementSource === 'manual') {
+        continue;
+      }
+      if (picture.lat === undefined || picture.lon === undefined) {
+        continue;
+      }
+
+      const match = projectCoordinateToJourney(
+        computedJourney,
+        picture.lat,
+        picture.lon,
+        picture.progress,
+        routeTimingMode,
+      );
+
+      if (!match || Math.abs(match.progress - picture.progress) <= TOLERANCE) {
+        continue;
+      }
+
+      store.updatePicturePosition(picture.id, match.progress);
+    }
+  }, [isExporting, journeySegments, pictureCount, routeTimingMode, tracks]);
+}

--- a/app/src/hooks/usePictureRouteSync.ts
+++ b/app/src/hooks/usePictureRouteSync.ts
@@ -1,27 +1,25 @@
 import { useEffect } from 'react';
 import { useAppStore } from '@/store/useAppStore';
-import { buildComputedJourney } from '@/utils/journeyUtils';
-import { projectCoordinateToJourney } from '@/utils/routeProjection';
+import { buildComputedJourney, progressForRouteDistance } from '@/utils/journeyUtils';
 
 /**
- * Haelt die Einordnung der Fotos auf der Strecke aktuell.
+ * Keeps photo timing in step with the route and the timing mode.
  *
- * Die Stelle eines Fotos wurde bisher nur einmal beim Einfuegen berechnet -
- * mit dem Massstab, der gerade eingestellt war. Wer die Fotos einfuegt und
- * ERST DANACH auf Constant Pace umschaltet, behielt deshalb die alte, nach
- * Messpunkten gezaehlte Stelle: Das Foto erschien im Video deutlich hinter
- * der Stelle, an der es aufgenommen wurde. Dasselbe galt fuer geladene
- * Projektdateien, die den alten Wert mitbringen.
+ * A photo's `progress` is computed once, when it is added, using whichever
+ * timing mode is active at that moment. Add the photos first and switch to
+ * Constant Pace afterwards and a photo keeps its old, point-counted value: it
+ * then appears well behind the place it was taken.
  *
- * Wichtig fuer die Ausloeser unten: Der Durchlauf haengt bewusst NICHT an
- * der Fotoliste selbst, sondern nur an Anzahl, Strecke und Massstab. Sonst
- * wuerde jede geschriebene Stelle den Effekt erneut ausloesen - und auf
- * einer Hin-und-Rueckstrecke, wo Hin- und Rueckweg uebereinanderliegen,
- * koennte die Zuordnung zwischen beiden Aesten hin- und herspringen und
- * die Oberflaeche endlos neu rechnen. So laeuft je Aenderung genau ein
- * Durchgang. Waehrend eines Exports bleibt er ganz aus.
+ * The recalculation uses the anchor the placement already established -
+ * `routeDistance`, the distance from the start of the journey - and never
+ * looks the photo up on the route again. Distance along the route increases
+ * monotonically, so it names one specific point even where an out-and-back
+ * route covers the same coordinates twice; searching by coordinates could
+ * land on the wrong leg. Photos without an anchor - placed by hand, or coming
+ * from a project saved before this field existed - are left untouched.
  *
- * Von Hand gesetzte Fotos werden nie angetastet.
+ * The effect deliberately does not depend on the picture list it writes to,
+ * only on route and timing mode, so one change means exactly one pass.
  */
 const TOLERANCE = 1e-6;
 
@@ -44,26 +42,22 @@ export function usePictureRouteSync() {
     }
 
     for (const picture of store.pictures) {
-      if (picture.placementSource === 'manual') {
-        continue;
-      }
-      if (picture.lat === undefined || picture.lon === undefined) {
+      if (picture.placementSource === 'manual' || picture.routeDistance === undefined) {
         continue;
       }
 
-      const match = projectCoordinateToJourney(
-        computedJourney,
-        picture.lat,
-        picture.lon,
-        picture.progress,
+      const progress = progressForRouteDistance(
+        computedJourney.coordinates,
+        computedJourney.segmentTimings,
+        picture.routeDistance,
         routeTimingMode,
       );
 
-      if (!match || Math.abs(match.progress - picture.progress) <= TOLERANCE) {
+      if (progress === null || Math.abs(progress - picture.progress) <= TOLERANCE) {
         continue;
       }
 
-      store.updatePicturePosition(picture.id, match.progress);
+      store.updatePicturePosition(picture.id, progress);
     }
   }, [isExporting, journeySegments, pictureCount, routeTimingMode, tracks]);
 }

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -77,6 +77,16 @@ export interface PictureAnnotation {
   timestamp?: Date;
   progress: number;
   position: number;
+  /**
+   * Where the photo sits along the route, in metres from the journey start.
+   *
+   * `progress` depends on the timing mode and therefore has to be recomputed
+   * when that mode changes. Distance along the route does not: it increases
+   * monotonically, so it identifies the point unambiguously even where the
+   * route crosses itself or doubles back, and both timing modes can be
+   * derived from it.
+   */
+  routeDistance?: number;
   placementSource?: 'gps' | 'timestamp' | 'manual';
   title?: string;
   description?: string;

--- a/app/src/utils/journeyUtils.ts
+++ b/app/src/utils/journeyUtils.ts
@@ -714,9 +714,24 @@ export function getJourneyElevationData(
       ? timing.endCoordIndex - timing.startCoordIndex + 1
       : 1;
     const segmentPointOffset = timing ? i - timing.startCoordIndex : 0;
-    const segmentProgress = segmentPointCount > 1
+    const indexProgress = segmentPointCount > 1
       ? Math.max(0, Math.min(1, segmentPointOffset / (segmentPointCount - 1)))
       : 0;
+
+    // Bei Constant Pace laeuft der Ruecklauf nach Kilometern. Wird die Lage im
+    // Abschnitt trotzdem nach Messpunkt-Nummer bestimmt, wandert ein Gipfel im
+    // Profil nach hinten, weil bergauf mehr Punkte je Kilometer entstehen -
+    // genau der Versatz zwischen Marker, Hoehenprofil und Fotos.
+    const spanStartDistance = timing ? coordinates[timing.startCoordIndex]?.distance : undefined;
+    const spanEndDistance = timing ? coordinates[timing.endCoordIndex]?.distance : undefined;
+    const distanceSpan = spanStartDistance !== undefined && spanEndDistance !== undefined
+      ? spanEndDistance - spanStartDistance
+      : 0;
+    const distanceProgress = routeTimingMode === 'uniform' && distanceSpan > 0 && spanStartDistance !== undefined
+      ? Math.max(0, Math.min(1, (point.distance - spanStartDistance) / distanceSpan))
+      : null;
+
+    const segmentProgress = distanceProgress ?? indexProgress;
     const progressStart = routeTimingMode === 'uniform'
       ? timing?.distanceStartRatio ?? 0
       : timing?.progressStartRatio ?? 0;

--- a/app/src/utils/journeyUtils.ts
+++ b/app/src/utils/journeyUtils.ts
@@ -307,6 +307,70 @@ function clampDistance(distance: number, totalDistance: number) {
   return Math.max(0, Math.min(distance, totalDistance));
 }
 
+/**
+ * Convert a position given in metres along the route into replay progress.
+ *
+ * Anything anchored to the route - a photo, an annotation - is best stored as
+ * a distance: that value is independent of the timing mode and, unlike a pair
+ * of coordinates, unambiguous where the route doubles back on itself. This is
+ * the one place that turns such an anchor into the progress value the replay
+ * uses, for either timing mode.
+ */
+export function progressForRouteDistance(
+  coordinates: JourneyPoint[],
+  segmentTimings: SegmentTiming[],
+  routeDistance: number,
+  routeTimingMode: RouteTimingMode = 'recorded'
+): number | null {
+  if (segmentTimings.length === 0 || !Number.isFinite(routeDistance)) return null;
+
+  const timing = segmentTimings.find(
+    (candidate) => routeDistance >= candidate.startDistance && routeDistance <= candidate.endDistance
+  ) ?? (routeDistance < segmentTimings[0].startDistance
+    ? segmentTimings[0]
+    : segmentTimings[segmentTimings.length - 1]);
+
+  const span = timing.endDistance - timing.startDistance;
+  // Distance within this segment. Track coordinates carry the distance from
+  // their own track's start, so the segment offset has to come off first.
+  const localDistance = Math.max(0, Math.min(span, routeDistance - timing.startDistance));
+
+  if (routeTimingMode === 'uniform') {
+    const localRatio = span > 0 ? localDistance / span : 0;
+    return clamp01(
+      timing.distanceStartRatio + localRatio * (timing.distanceEndRatio - timing.distanceStartRatio)
+    );
+  }
+
+  // Recorded pace counts measurement points, so walk the segment's points to
+  // find the one this distance falls on.
+  const { startCoordIndex, endCoordIndex } = timing;
+  if (endCoordIndex <= startCoordIndex) return clamp01(timing.progressStartRatio);
+
+  let exactIndex = endCoordIndex;
+  for (let index = startCoordIndex; index < endCoordIndex; index += 1) {
+    const current = coordinates[index]?.distance;
+    const next = coordinates[index + 1]?.distance;
+    if (current === undefined || next === undefined) continue;
+    if (localDistance <= next) {
+      const step = next - current;
+      const fraction = step > 0 ? Math.max(0, Math.min(1, (localDistance - current) / step)) : 0;
+      exactIndex = index + fraction;
+      break;
+    }
+  }
+
+  const coordSpan = Math.max(endCoordIndex - startCoordIndex, 1);
+  const localRatio = (exactIndex - startCoordIndex) / coordSpan;
+  return clamp01(
+    timing.progressStartRatio + localRatio * (timing.progressEndRatio - timing.progressStartRatio)
+  );
+}
+
+function clamp01(value: number) {
+  return Math.max(0, Math.min(1, value));
+}
+
 function interpolateNullableNumber(
   start: number | null,
   end: number | null,

--- a/app/src/utils/photoPlacement.ts
+++ b/app/src/utils/photoPlacement.ts
@@ -68,6 +68,9 @@ function createPicture(params: {
       timestamp,
       progress: match.progress ?? fallbackProgress,
       position: match.progress ?? fallbackProgress,
+      // Keeps the point the placement actually found, so a later change of
+      // timing mode can be recalculated from it rather than searched for.
+      routeDistance: match.routeDistance,
       placementSource,
       displayDuration: 5000,
     },

--- a/app/src/utils/photoPlacementDistance.test.ts
+++ b/app/src/utils/photoPlacementDistance.test.ts
@@ -1,24 +1,34 @@
 import { describe, expect, it } from 'vitest';
 import type { GPXPoint, GPXTrack } from '@/types';
-import { buildComputedJourney, getJourneyElevationData } from '@/utils/journeyUtils';
+import {
+  buildComputedJourney,
+  getJourneyElevationData,
+  progressForRouteDistance,
+} from '@/utils/journeyUtils';
+import { findTimestampPlacement } from '@/utils/photoTimelinePlacement';
 import { projectCoordinateToJourney } from '@/utils/routeProjection';
 
 /**
- * Eine Bergfahrt mit ungleichmaessiger Aufzeichnungsdichte.
+ * A climb recorded at an uneven sampling rate.
  *
- * Bergauf wird langsam gefahren, das Geraet zeichnet dort viele Punkte je
- * Kilometer auf; bergab wenige. Genau diese Ungleichverteilung liess Marker,
- * Hoehenprofil und Fotos im Video auseinanderlaufen: Der Marker zaehlte nach
- * Kilometern, die beiden anderen nach Messpunkt-Nummer.
+ * Riding uphill is slow, so the device records many points per kilometre;
+ * riding down again is fast and records few. That imbalance is what pulled
+ * the marker, the elevation profile and the photos apart in the video: the
+ * marker counted kilometres, the other two counted measurement points.
+ *
+ * The descent returns along the same line as the climb — an out-and-back —
+ * so every coordinate on the way up appears a second time on the way down.
  */
+const START_TIME = Date.UTC(2026, 4, 1, 8, 0, 0);
+
 function makeBergTrack(): GPXTrack {
   const points: GPXPoint[] = [];
-  const push = (lat: number, elevation: number, distance: number) => {
+  const push = (lat: number, elevation: number, distance: number, minutes: number) => {
     points.push({
       lat,
       lon: 10.0,
       elevation,
-      time: null,
+      time: new Date(START_TIME + minutes * 60_000),
       heartRate: null,
       cadence: null,
       power: null,
@@ -28,20 +38,20 @@ function makeBergTrack(): GPXTrack {
     });
   };
 
-  // Anstieg: 40 Punkte auf 4000 m (alle 100 m ein Punkt)
+  // Climb: 40 points over 4000 m, one every 100 m, two minutes apart.
   for (let i = 0; i < 40; i += 1) {
-    push(51.0 + i * 0.001, 500 + i * 16, i * 100);
+    push(51.0 + i * 0.001, 500 + i * 16, i * 100, i * 2);
   }
-  // Gipfel bei 4000 m Streckenlaenge
-  push(51.04, 1140, 4000);
-  // Abfahrt: nur 10 Punkte auf ebenfalls 4000 m (alle 400 m ein Punkt)
+  // Summit at 4000 m into the ride.
+  push(51.04, 1140, 4000, 80);
+  // Descent: back down the same line, 10 points over 4000 m.
   for (let i = 1; i <= 10; i += 1) {
-    push(51.04 - i * 0.004, 1140 - i * 64, 4000 + i * 400);
+    push(51.04 - i * 0.004, 1140 - i * 64, 4000 + i * 400, 80 + i);
   }
 
   return {
     id: 'berg', name: 'Bergfahrt', activityIcon: '🚴', points,
-    totalDistance: 8000, totalTime: 3600, movingTime: 3600,
+    totalDistance: 8000, totalTime: 5400, movingTime: 5400,
     elevationGain: 640, elevationLoss: 640, maxElevation: 1140, minElevation: 500,
     maxSpeed: 10, avgSpeed: 5, avgMovingSpeed: 5,
     bounds: { minLat: 51.0, maxLat: 51.04, minLon: 10.0, maxLon: 10.0 },
@@ -51,86 +61,109 @@ function makeBergTrack(): GPXTrack {
 
 const track = makeBergTrack();
 const segments = [{ id: 'seg', type: 'track' as const, trackId: 'berg', duration: 60_000 }];
-const journey = buildComputedJourney(segments, [track]);
+const journey = buildComputedJourney(segments, [track])!;
 
-/** Der Gipfel liegt bei genau der Haelfte der Strecke. */
-const GIPFEL_NACH_STRECKE = 0.5;
-/** Nach Punktnummer liegt er dagegen bei 40 von 50 Punkten - also viel zu spaet. */
-const GIPFEL_NACH_PUNKTNUMMER = 40 / 50;
+/** The summit is exactly halfway by distance. */
+const SUMMIT_BY_DISTANCE = 0.5;
+/** By point number it is at 40 of 50 points — far too late. */
+const SUMMIT_BY_POINT_INDEX = 40 / 50;
+/** Metres into the ride where the summit photo was taken. */
+const SUMMIT_ROUTE_DISTANCE = 4000;
 
-describe('Einordnung bei Constant Pace', () => {
-  it('ordnet ein Gipfelfoto nach Entfernung ein, nicht nach Punktnummer', () => {
-    expect(journey).not.toBeNull();
-
-    const match = projectCoordinateToJourney(journey!, 51.04, 10.0, 0, 'uniform');
+describe('Constant Pace placement', () => {
+  it('places a summit photo by distance, not by point number', () => {
+    const match = projectCoordinateToJourney(journey, 51.04, 10.0, 0, 'uniform');
 
     expect(match).not.toBeNull();
-    expect(match!.progress).toBeCloseTo(GIPFEL_NACH_STRECKE, 2);
-    // Der alte Wert lag rund 30 Prozentpunkte daneben - das war der Versatz.
-    expect(Math.abs(match!.progress - GIPFEL_NACH_PUNKTNUMMER)).toBeGreaterThan(0.2);
+    expect(match!.progress).toBeCloseTo(SUMMIT_BY_DISTANCE, 2);
+    // The old value was about 30 percentage points out — that was the offset.
+    expect(Math.abs(match!.progress - SUMMIT_BY_POINT_INDEX)).toBeGreaterThan(0.2);
   });
 
-  it('setzt den Gipfel im Hoehenprofil an dieselbe Stelle', () => {
-    const daten = getJourneyElevationData(journey!.coordinates, journey!.segmentTimings, 'uniform');
-    const gipfel = daten.reduce((hoechster, punkt) => punkt.elevation > hoechster.elevation ? punkt : hoechster);
+  it('puts the summit at the same place in the elevation profile', () => {
+    const data = getJourneyElevationData(journey.coordinates, journey.segmentTimings, 'uniform');
+    const summit = data.reduce((highest, point) => point.elevation > highest.elevation ? point : highest);
 
-    expect(gipfel.elevation).toBe(1140);
-    expect(gipfel.progress).toBeCloseTo(GIPFEL_NACH_STRECKE, 2);
+    expect(summit.elevation).toBe(1140);
+    expect(summit.progress).toBeCloseTo(SUMMIT_BY_DISTANCE, 2);
   });
 
-  it('bringt Foto und Hoehenprofil auf denselben Wert', () => {
-    const match = projectCoordinateToJourney(journey!, 51.04, 10.0, 0, 'uniform');
-    const daten = getJourneyElevationData(journey!.coordinates, journey!.segmentTimings, 'uniform');
-    const gipfel = daten.reduce((hoechster, punkt) => punkt.elevation > hoechster.elevation ? punkt : hoechster);
+  it('brings photo and elevation profile to the same value', () => {
+    const match = projectCoordinateToJourney(journey, 51.04, 10.0, 0, 'uniform');
+    const data = getJourneyElevationData(journey.coordinates, journey.segmentTimings, 'uniform');
+    const summit = data.reduce((highest, point) => point.elevation > highest.elevation ? point : highest);
 
-    expect(Math.abs(match!.progress - gipfel.progress)).toBeLessThan(0.02);
+    expect(Math.abs(match!.progress - summit.progress)).toBeLessThan(0.02);
   });
 });
 
-describe('Real Pace bleibt unveraendert', () => {
-  it('ordnet weiterhin nach Messpunkten ein', () => {
-    const match = projectCoordinateToJourney(journey!, 51.04, 10.0, 0, 'recorded');
+describe('Real Pace placement is unchanged', () => {
+  it('still places by measurement point', () => {
+    const match = projectCoordinateToJourney(journey, 51.04, 10.0, 0, 'recorded');
 
     expect(match).not.toBeNull();
-    expect(match!.progress).toBeCloseTo(GIPFEL_NACH_PUNKTNUMMER, 1);
+    expect(match!.progress).toBeCloseTo(SUMMIT_BY_POINT_INDEX, 1);
   });
 });
 
-/**
- * Die Stelle eines Fotos wurde bisher nur beim Einfuegen berechnet. Wer die
- * Fotos zuerst einfuegt und danach auf Constant Pace umschaltet, behielt den
- * alten Wert. usePictureRouteSync rechnet deshalb aus den gespeicherten
- * Koordinaten neu - diese Tests sichern, dass das zuverlaessig geht.
- */
-describe('Nachtraegliches Umschalten des Massstabs', () => {
-  it('korrigiert ein zuvor nach Messpunkten eingeordnetes Foto', () => {
-    // Einfuegen bei Real Pace: Das Foto merkt sich den Punkt auf der Strecke.
-    const beimEinfuegen = projectCoordinateToJourney(journey!, 51.04, 10.0, 0, 'recorded');
-    expect(beimEinfuegen!.progress).toBeCloseTo(GIPFEL_NACH_PUNKTNUMMER, 1);
+describe('The anchor kept with the photo', () => {
+  it('records where on the route a GPS placement landed', () => {
+    const match = projectCoordinateToJourney(journey, 51.02, 10.0, 0, 'uniform');
 
-    // Spaeter auf Constant Pace umgeschaltet: Neuberechnung aus denselben
-    // gespeicherten Koordinaten.
-    const nachUmschalten = projectCoordinateToJourney(
-      journey!,
-      beimEinfuegen!.lat,
-      beimEinfuegen!.lon,
-      beimEinfuegen!.progress,
-      'uniform',
-    );
-
-    expect(nachUmschalten!.progress).toBeCloseTo(GIPFEL_NACH_STRECKE, 2);
+    expect(match!.routeDistance).toBeCloseTo(2000, 0);
   });
 
-  it('bleibt bei wiederholter Neuberechnung stabil', () => {
-    const ersteRechnung = projectCoordinateToJourney(journey!, 51.04, 10.0, 0, 'uniform');
-    const zweiteRechnung = projectCoordinateToJourney(
-      journey!,
-      ersteRechnung!.lat,
-      ersteRechnung!.lon,
-      ersteRechnung!.progress,
-      'uniform',
+  it('records where on the route a timestamp placement landed', () => {
+    // 85 minutes in — five minutes past the summit, on the way down. Its
+    // coordinates are the same as the point 2 km into the climb.
+    const placement = findTimestampPlacement({
+      timestamp: new Date(START_TIME + 85 * 60_000),
+      tracks: [track],
+      journeySegments: segments,
+      computedJourney: journey,
+      activeTrackId: 'berg',
+      routeTimingMode: 'uniform',
+    });
+
+    expect(placement.match).not.toBeNull();
+    expect(placement.match!.lat).toBeCloseTo(51.02, 4);
+    // Five points down the descent: 4000 m of climb plus 5 × 400 m. The
+    // identical spot on the way up would be 2000 m.
+    expect(placement.match!.routeDistance).toBeCloseTo(6000, 0);
+  });
+
+  it('keeps a photo on the leg it belongs to when the mode changes', () => {
+    // On the way down, level with the point 2 km into the climb. Its
+    // coordinates appear twice on this route; only the anchor distinguishes
+    // the two, and recalculating must not move the photo to the other leg.
+    const onTheWayDown = 6000;
+
+    const uniform = progressForRouteDistance(
+      journey.coordinates, journey.segmentTimings, onTheWayDown, 'uniform',
+    );
+    const recorded = progressForRouteDistance(
+      journey.coordinates, journey.segmentTimings, onTheWayDown, 'recorded',
     );
 
-    expect(zweiteRechnung!.progress).toBeCloseTo(ersteRechnung!.progress, 6);
+    // Three quarters of the distance, but 45 of 50 points.
+    expect(uniform).toBeCloseTo(0.75, 2);
+    expect(recorded).toBeCloseTo(45 / 50, 2);
+
+    // Searching for the nearest coordinate instead would find the identical
+    // point on the way up and place the photo at half that distance.
+    const byCoordinates = projectCoordinateToJourney(journey, 51.02, 10.0, 0, 'uniform');
+    expect(byCoordinates!.progress).toBeLessThan(0.3);
+  });
+
+  it('is stable when recalculated repeatedly', () => {
+    const once = progressForRouteDistance(
+      journey.coordinates, journey.segmentTimings, SUMMIT_ROUTE_DISTANCE, 'uniform',
+    );
+    const twice = progressForRouteDistance(
+      journey.coordinates, journey.segmentTimings, SUMMIT_ROUTE_DISTANCE, 'uniform',
+    );
+
+    expect(twice).toBeCloseTo(once!, 6);
+    expect(once).toBeCloseTo(SUMMIT_BY_DISTANCE, 2);
   });
 });

--- a/app/src/utils/photoPlacementDistance.test.ts
+++ b/app/src/utils/photoPlacementDistance.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it } from 'vitest';
+import type { GPXPoint, GPXTrack } from '@/types';
+import { buildComputedJourney, getJourneyElevationData } from '@/utils/journeyUtils';
+import { projectCoordinateToJourney } from '@/utils/routeProjection';
+
+/**
+ * Eine Bergfahrt mit ungleichmaessiger Aufzeichnungsdichte.
+ *
+ * Bergauf wird langsam gefahren, das Geraet zeichnet dort viele Punkte je
+ * Kilometer auf; bergab wenige. Genau diese Ungleichverteilung liess Marker,
+ * Hoehenprofil und Fotos im Video auseinanderlaufen: Der Marker zaehlte nach
+ * Kilometern, die beiden anderen nach Messpunkt-Nummer.
+ */
+function makeBergTrack(): GPXTrack {
+  const points: GPXPoint[] = [];
+  const push = (lat: number, elevation: number, distance: number) => {
+    points.push({
+      lat,
+      lon: 10.0,
+      elevation,
+      time: null,
+      heartRate: null,
+      cadence: null,
+      power: null,
+      temperature: null,
+      distance,
+      speed: 0,
+    });
+  };
+
+  // Anstieg: 40 Punkte auf 4000 m (alle 100 m ein Punkt)
+  for (let i = 0; i < 40; i += 1) {
+    push(51.0 + i * 0.001, 500 + i * 16, i * 100);
+  }
+  // Gipfel bei 4000 m Streckenlaenge
+  push(51.04, 1140, 4000);
+  // Abfahrt: nur 10 Punkte auf ebenfalls 4000 m (alle 400 m ein Punkt)
+  for (let i = 1; i <= 10; i += 1) {
+    push(51.04 - i * 0.004, 1140 - i * 64, 4000 + i * 400);
+  }
+
+  return {
+    id: 'berg', name: 'Bergfahrt', activityIcon: '🚴', points,
+    totalDistance: 8000, totalTime: 3600, movingTime: 3600,
+    elevationGain: 640, elevationLoss: 640, maxElevation: 1140, minElevation: 500,
+    maxSpeed: 10, avgSpeed: 5, avgMovingSpeed: 5,
+    bounds: { minLat: 51.0, maxLat: 51.04, minLon: 10.0, maxLon: 10.0 },
+    color: '#000', visible: true,
+  };
+}
+
+const track = makeBergTrack();
+const segments = [{ id: 'seg', type: 'track' as const, trackId: 'berg', duration: 60_000 }];
+const journey = buildComputedJourney(segments, [track]);
+
+/** Der Gipfel liegt bei genau der Haelfte der Strecke. */
+const GIPFEL_NACH_STRECKE = 0.5;
+/** Nach Punktnummer liegt er dagegen bei 40 von 50 Punkten - also viel zu spaet. */
+const GIPFEL_NACH_PUNKTNUMMER = 40 / 50;
+
+describe('Einordnung bei Constant Pace', () => {
+  it('ordnet ein Gipfelfoto nach Entfernung ein, nicht nach Punktnummer', () => {
+    expect(journey).not.toBeNull();
+
+    const match = projectCoordinateToJourney(journey!, 51.04, 10.0, 0, 'uniform');
+
+    expect(match).not.toBeNull();
+    expect(match!.progress).toBeCloseTo(GIPFEL_NACH_STRECKE, 2);
+    // Der alte Wert lag rund 30 Prozentpunkte daneben - das war der Versatz.
+    expect(Math.abs(match!.progress - GIPFEL_NACH_PUNKTNUMMER)).toBeGreaterThan(0.2);
+  });
+
+  it('setzt den Gipfel im Hoehenprofil an dieselbe Stelle', () => {
+    const daten = getJourneyElevationData(journey!.coordinates, journey!.segmentTimings, 'uniform');
+    const gipfel = daten.reduce((hoechster, punkt) => punkt.elevation > hoechster.elevation ? punkt : hoechster);
+
+    expect(gipfel.elevation).toBe(1140);
+    expect(gipfel.progress).toBeCloseTo(GIPFEL_NACH_STRECKE, 2);
+  });
+
+  it('bringt Foto und Hoehenprofil auf denselben Wert', () => {
+    const match = projectCoordinateToJourney(journey!, 51.04, 10.0, 0, 'uniform');
+    const daten = getJourneyElevationData(journey!.coordinates, journey!.segmentTimings, 'uniform');
+    const gipfel = daten.reduce((hoechster, punkt) => punkt.elevation > hoechster.elevation ? punkt : hoechster);
+
+    expect(Math.abs(match!.progress - gipfel.progress)).toBeLessThan(0.02);
+  });
+});
+
+describe('Real Pace bleibt unveraendert', () => {
+  it('ordnet weiterhin nach Messpunkten ein', () => {
+    const match = projectCoordinateToJourney(journey!, 51.04, 10.0, 0, 'recorded');
+
+    expect(match).not.toBeNull();
+    expect(match!.progress).toBeCloseTo(GIPFEL_NACH_PUNKTNUMMER, 1);
+  });
+});
+
+/**
+ * Die Stelle eines Fotos wurde bisher nur beim Einfuegen berechnet. Wer die
+ * Fotos zuerst einfuegt und danach auf Constant Pace umschaltet, behielt den
+ * alten Wert. usePictureRouteSync rechnet deshalb aus den gespeicherten
+ * Koordinaten neu - diese Tests sichern, dass das zuverlaessig geht.
+ */
+describe('Nachtraegliches Umschalten des Massstabs', () => {
+  it('korrigiert ein zuvor nach Messpunkten eingeordnetes Foto', () => {
+    // Einfuegen bei Real Pace: Das Foto merkt sich den Punkt auf der Strecke.
+    const beimEinfuegen = projectCoordinateToJourney(journey!, 51.04, 10.0, 0, 'recorded');
+    expect(beimEinfuegen!.progress).toBeCloseTo(GIPFEL_NACH_PUNKTNUMMER, 1);
+
+    // Spaeter auf Constant Pace umgeschaltet: Neuberechnung aus denselben
+    // gespeicherten Koordinaten.
+    const nachUmschalten = projectCoordinateToJourney(
+      journey!,
+      beimEinfuegen!.lat,
+      beimEinfuegen!.lon,
+      beimEinfuegen!.progress,
+      'uniform',
+    );
+
+    expect(nachUmschalten!.progress).toBeCloseTo(GIPFEL_NACH_STRECKE, 2);
+  });
+
+  it('bleibt bei wiederholter Neuberechnung stabil', () => {
+    const ersteRechnung = projectCoordinateToJourney(journey!, 51.04, 10.0, 0, 'uniform');
+    const zweiteRechnung = projectCoordinateToJourney(
+      journey!,
+      ersteRechnung!.lat,
+      ersteRechnung!.lon,
+      ersteRechnung!.progress,
+      'uniform',
+    );
+
+    expect(zweiteRechnung!.progress).toBeCloseTo(ersteRechnung!.progress, 6);
+  });
+});

--- a/app/src/utils/photoTimelinePlacement.ts
+++ b/app/src/utils/photoTimelinePlacement.ts
@@ -1,5 +1,6 @@
-import type { GPXPoint, GPXTrack, JourneySegment, TrackSegment } from '@/types';
+import type { GPXPoint, GPXTrack, JourneySegment, RouteTimingMode, TrackSegment } from '@/types';
 import type { ComputedJourney, SegmentTiming } from '@/utils/journeyUtils';
+import { progressForRouteDistance } from '@/utils/journeyUtils';
 
 export type TimestampPlacementFailureReason =
   | 'missing-timestamp'
@@ -10,6 +11,12 @@ export interface TimestampPlacementMatch {
   lat: number;
   lon: number;
   progress: number;
+  /**
+   * Where the match sits along the journey, in metres from its start. Absent
+   * when the match was made against a single loose track rather than a
+   * journey, where there is no journey-wide distance to refer to.
+   */
+  routeDistance?: number;
 }
 
 interface TimestampPlacementResult {
@@ -37,6 +44,9 @@ function interpolateBetweenTimedPoints(
     lat: lower.point.lat + (upper.point.lat - lower.point.lat) * ratio,
     lon: lower.point.lon + (upper.point.lon - lower.point.lon) * ratio,
     exactPointIndex: lower.index + (upper.index - lower.index) * ratio,
+    // Distance from the start of this track, interpolated the same way. It is
+    // what anchors the photo to one specific place on the route.
+    trackDistance: lower.point.distance + (upper.point.distance - lower.point.distance) * ratio,
   };
 }
 
@@ -120,6 +130,7 @@ function matchTimestampOnJourneyTrackSegment(
         lat: interpolated.lat,
         lon: interpolated.lon,
         progress: progressForSegmentPointIndex(segmentTiming, interpolated.exactPointIndex, track.points.length),
+        routeDistance: segmentTiming.startDistance + interpolated.trackDistance,
       },
       reason: null,
     };
@@ -134,8 +145,10 @@ export function findTimestampPlacement(params: {
   journeySegments: JourneySegment[];
   computedJourney: ComputedJourney | null;
   activeTrackId: string | null;
+  /** Constant Pace ('uniform') times the replay by distance, not by point. */
+  routeTimingMode?: RouteTimingMode;
 }): TimestampPlacementResult {
-  const { activeTrackId, computedJourney, journeySegments, timestamp, tracks } = params;
+  const { activeTrackId, computedJourney, journeySegments, routeTimingMode = 'recorded', timestamp, tracks } = params;
 
   if (!timestamp || Number.isNaN(timestamp.getTime())) {
     return { match: null, reason: 'missing-timestamp' };
@@ -168,7 +181,22 @@ export function findTimestampPlacement(params: {
 
       const result = matchTimestampOnJourneyTrackSegment(track, segmentTiming, timestampMs);
       if (result.match) {
-        return result;
+        // The timestamp already picked the exact point on the route. Turn that
+        // one point into progress for the active timing mode - the point
+        // itself is never looked up again, so the photo cannot wander to
+        // another part of the track.
+        const progress = result.match.routeDistance !== undefined
+          ? progressForRouteDistance(
+            computedJourney.coordinates,
+            computedJourney.segmentTimings,
+            result.match.routeDistance,
+            routeTimingMode,
+          )
+          : null;
+
+        return progress === null
+          ? result
+          : { match: { ...result.match, progress }, reason: null };
       }
     }
 

--- a/app/src/utils/projectFile/buildReplayArchive.ts
+++ b/app/src/utils/projectFile/buildReplayArchive.ts
@@ -57,6 +57,7 @@ function serializePicture(picture: AppState['pictures'][number]): SerializedPict
     timestamp: picture.timestamp?.toISOString(),
     progress: picture.progress,
     position: picture.position,
+    routeDistance: picture.routeDistance,
     placementSource: picture.placementSource,
     title: picture.title,
     description: picture.description,

--- a/app/src/utils/projectFile/hydrateProject.test.ts
+++ b/app/src/utils/projectFile/hydrateProject.test.ts
@@ -70,4 +70,52 @@ describe('hydrateProject', () => {
 
     expect(state.settings.unitSystem).toBe('imperial');
   });
+
+  it('carries a photo route anchor through a save and reopen', async () => {
+    const sourceStore = createAppStore();
+    sourceStore.getState().addTrack(parseGPX(sampleGpx, 'ridge-loop.gpx'));
+    sourceStore.getState().addPicture({
+      id: 'picture-anchored',
+      file: new File(['image'], 'summit.jpg', { type: 'image/jpeg' }),
+      url: 'blob:summit',
+      isPlaceholder: false,
+      progress: 0.5,
+      position: 0.5,
+      // Metres from the start of the journey. Without it, a reopened project
+      // cannot be recalculated when the timing mode changes afterwards.
+      routeDistance: 1234,
+      placementSource: 'gps',
+      displayDuration: 5000,
+    });
+
+    const blob = await buildReplayArchive(sourceStore.getState());
+    const parsed = await parseReplayArchive(new File([blob], 'project.replay'));
+
+    const targetStore = createAppStore();
+    hydrateProject(parsed, targetStore.getState());
+
+    expect(targetStore.getState().pictures[0].routeDistance).toBe(1234);
+  });
+
+  it('leaves the anchor absent for projects saved before it existed', async () => {
+    const sourceStore = createAppStore();
+    sourceStore.getState().addTrack(parseGPX(sampleGpx, 'ridge-loop.gpx'));
+    sourceStore.getState().addPicture({
+      id: 'picture-legacy',
+      file: new File(['image'], 'old.jpg', { type: 'image/jpeg' }),
+      url: 'blob:old',
+      isPlaceholder: false,
+      progress: 0.25,
+      position: 0.25,
+      displayDuration: 5000,
+    });
+
+    const blob = await buildReplayArchive(sourceStore.getState());
+    const parsed = await parseReplayArchive(new File([blob], 'project.replay'));
+
+    const targetStore = createAppStore();
+    hydrateProject(parsed, targetStore.getState());
+
+    expect(targetStore.getState().pictures[0].routeDistance).toBeUndefined();
+  });
 });

--- a/app/src/utils/projectFile/hydrateProject.ts
+++ b/app/src/utils/projectFile/hydrateProject.ts
@@ -15,6 +15,7 @@ function hydratePicture(serialized: SerializedPicture): PictureAnnotation {
     timestamp: serialized.timestamp ? new Date(serialized.timestamp) : undefined,
     progress: serialized.progress,
     position: serialized.position,
+    routeDistance: serialized.routeDistance,
     placementSource: serialized.placementSource,
     title: serialized.title,
     description: serialized.description,

--- a/app/src/utils/projectFile/types.ts
+++ b/app/src/utils/projectFile/types.ts
@@ -56,6 +56,13 @@ export interface SerializedPicture {
   timestamp?: string;
   progress: number;
   position: number;
+  /**
+   * Distance from the start of the journey, in metres. `progress` depends on
+   * the timing mode; this does not, so it is what lets a reopened project be
+   * recalculated when the mode changes afterwards. Absent in projects saved
+   * before this field existed.
+   */
+  routeDistance?: number;
   placementSource?: 'gps' | 'timestamp' | 'manual';
   title?: string;
   description?: string;

--- a/app/src/utils/routeProjection.ts
+++ b/app/src/utils/routeProjection.ts
@@ -1,4 +1,4 @@
-import type { GPXTrack } from '@/types';
+import type { GPXTrack, RouteTimingMode } from '@/types';
 import type { ComputedJourney, SegmentTiming } from '@/utils/journeyUtils';
 import { calculateDistance } from '@/utils/journeyUtils';
 
@@ -155,6 +155,38 @@ export function projectCoordinateToTracks(
   return bestMatch;
 }
 
+/**
+ * Ordnet einen Punkt nach ZURUECKGELEGTER STRECKE in die Tour ein.
+ *
+ * Der Ruecklauf zaehlt bei Constant Pace nach Kilometern, nicht nach
+ * Messpunkten. Wer bergauf langsam faehrt, erzeugt dort viel mehr Punkte je
+ * Kilometer - nach Punktnummer liegt ein Gipfel deshalb deutlich weiter hinten
+ * als nach Entfernung. Fotos landeten dadurch spuerbar hinter ihrer echten
+ * Stelle. Gibt null zurueck, wenn keine brauchbaren Entfernungen vorliegen.
+ */
+function distanceProgressForJourneySegment(
+  segmentTiming: SegmentTiming,
+  coordinates: ComputedJourney['coordinates'],
+  index: number,
+  fraction: number,
+): number | null {
+  const spanStart = coordinates[segmentTiming.startCoordIndex]?.distance;
+  const spanEnd = coordinates[segmentTiming.endCoordIndex]?.distance;
+  const start = coordinates[index];
+  const end = coordinates[index + 1];
+
+  if (spanStart === undefined || spanEnd === undefined || !start || !end) return null;
+
+  const span = spanEnd - spanStart;
+  if (!(span > 0)) return null;
+
+  const projectedDistance = start.distance + (end.distance - start.distance) * fraction;
+  const local = (projectedDistance - spanStart) / span;
+
+  return segmentTiming.distanceStartRatio +
+    local * (segmentTiming.distanceEndRatio - segmentTiming.distanceStartRatio);
+}
+
 function progressForJourneySegment(segmentTiming: SegmentTiming, startCoordIndex: number, exactIndex: number) {
   const segmentCoordCount = Math.max(segmentTiming.endCoordIndex - segmentTiming.startCoordIndex, 1);
   const localProgress = (exactIndex - startCoordIndex) / segmentCoordCount;
@@ -167,6 +199,8 @@ export function projectCoordinateToJourney(
   targetLat: number,
   targetLon: number,
   fallbackProgress: number,
+  /** Bei 'uniform' (Constant Pace) laeuft der Ruecklauf nach Entfernung. */
+  routeTimingMode: RouteTimingMode = 'recorded',
 ): RouteMatch | null {
   const { coordinates, segmentTimings } = computedJourney;
 
@@ -218,7 +252,11 @@ export function projectCoordinateToJourney(
         end.lon,
       );
       const exactIndex = index + projection.fraction;
-      const progress = progressForJourneySegment(segmentTiming, segmentTiming.startCoordIndex, exactIndex);
+      const distanceProgress = routeTimingMode === 'uniform'
+        ? distanceProgressForJourneySegment(segmentTiming, coordinates, index, projection.fraction)
+        : null;
+      const progress = distanceProgress ??
+        progressForJourneySegment(segmentTiming, segmentTiming.startCoordIndex, exactIndex);
 
       if (!bestMatch || projection.distanceMeters < bestMatch.distanceMeters) {
         bestMatch = {

--- a/app/src/utils/routeProjection.ts
+++ b/app/src/utils/routeProjection.ts
@@ -1,12 +1,17 @@
 import type { GPXTrack, RouteTimingMode } from '@/types';
 import type { ComputedJourney, SegmentTiming } from '@/utils/journeyUtils';
-import { calculateDistance } from '@/utils/journeyUtils';
+import { calculateDistance, progressForRouteDistance } from '@/utils/journeyUtils';
 
 export interface RouteMatch {
   progress: number;
   lat: number;
   lon: number;
   distanceMeters: number;
+  /**
+   * Where the match sits along the journey, in metres from its start. Absent
+   * when the match was made against loose tracks rather than a journey.
+   */
+  routeDistance?: number;
 }
 
 const METERS_PER_DEGREE_LAT = 111_320;
@@ -156,35 +161,23 @@ export function projectCoordinateToTracks(
 }
 
 /**
- * Ordnet einen Punkt nach ZURUECKGELEGTER STRECKE in die Tour ein.
+ * Distance from the journey start for a point between two coordinates.
  *
- * Der Ruecklauf zaehlt bei Constant Pace nach Kilometern, nicht nach
- * Messpunkten. Wer bergauf langsam faehrt, erzeugt dort viel mehr Punkte je
- * Kilometer - nach Punktnummer liegt ein Gipfel deshalb deutlich weiter hinten
- * als nach Entfernung. Fotos landeten dadurch spuerbar hinter ihrer echten
- * Stelle. Gibt null zurueck, wenn keine brauchbaren Entfernungen vorliegen.
+ * Track coordinates carry the distance from their own track's start, so the
+ * segment's offset within the journey has to be added back on.
  */
-function distanceProgressForJourneySegment(
+function routeDistanceForJourneySegment(
   segmentTiming: SegmentTiming,
   coordinates: ComputedJourney['coordinates'],
   index: number,
   fraction: number,
 ): number | null {
-  const spanStart = coordinates[segmentTiming.startCoordIndex]?.distance;
-  const spanEnd = coordinates[segmentTiming.endCoordIndex]?.distance;
   const start = coordinates[index];
   const end = coordinates[index + 1];
+  if (!start || !end) return null;
 
-  if (spanStart === undefined || spanEnd === undefined || !start || !end) return null;
-
-  const span = spanEnd - spanStart;
-  if (!(span > 0)) return null;
-
-  const projectedDistance = start.distance + (end.distance - start.distance) * fraction;
-  const local = (projectedDistance - spanStart) / span;
-
-  return segmentTiming.distanceStartRatio +
-    local * (segmentTiming.distanceEndRatio - segmentTiming.distanceStartRatio);
+  const localDistance = start.distance + (end.distance - start.distance) * fraction;
+  return segmentTiming.startDistance + localDistance;
 }
 
 function progressForJourneySegment(segmentTiming: SegmentTiming, startCoordIndex: number, exactIndex: number) {
@@ -231,7 +224,7 @@ export function projectCoordinateToJourney(
       const progress = segmentTiming.progressStartRatio;
       const candidate = matchSinglePoint(targetLat, targetLon, point.lat, point.lon, progress);
       if (!bestMatch || candidate.distanceMeters < bestMatch.distanceMeters) {
-        bestMatch = candidate;
+        bestMatch = { ...candidate, routeDistance: segmentTiming.startDistance + point.distance };
       }
       continue;
     }
@@ -251,21 +244,33 @@ export function projectCoordinateToJourney(
         end.lat,
         end.lon,
       );
-      const exactIndex = index + projection.fraction;
-      const distanceProgress = routeTimingMode === 'uniform'
-        ? distanceProgressForJourneySegment(segmentTiming, coordinates, index, projection.fraction)
-        : null;
-      const progress = distanceProgress ??
-        progressForJourneySegment(segmentTiming, segmentTiming.startCoordIndex, exactIndex);
-
-      if (!bestMatch || projection.distanceMeters < bestMatch.distanceMeters) {
-        bestMatch = {
-          lat: projection.lat,
-          lon: projection.lon,
-          progress: Math.max(0, Math.min(1, progress)),
-          distanceMeters: projection.distanceMeters,
-        };
+      if (bestMatch && projection.distanceMeters >= bestMatch.distanceMeters) {
+        continue;
       }
+
+      const exactIndex = index + projection.fraction;
+      const routeDistance = routeDistanceForJourneySegment(
+        segmentTiming,
+        coordinates,
+        index,
+        projection.fraction,
+      );
+      // Constant Pace advances by distance travelled. A slow climb records far
+      // more points per kilometre than a fast descent, so counting points puts
+      // a summit much later than counting kilometres - which is why photos
+      // showed up well behind the place they were taken.
+      const progress = routeDistance !== null
+        ? progressForRouteDistance(coordinates, segmentTimings, routeDistance, routeTimingMode)
+          ?? progressForJourneySegment(segmentTiming, segmentTiming.startCoordIndex, exactIndex)
+        : progressForJourneySegment(segmentTiming, segmentTiming.startCoordIndex, exactIndex);
+
+      bestMatch = {
+        lat: projection.lat,
+        lon: projection.lon,
+        progress: Math.max(0, Math.min(1, progress)),
+        distanceMeters: projection.distanceMeters,
+        routeDistance: routeDistance ?? undefined,
+      };
     }
   }
 


### PR DESCRIPTION
With `routeTimingMode: 'uniform'` the marker advances by **distance travelled**, but photos and the elevation profile were still positioned by **point index**:

- `projectCoordinateToJourney()` did not take `routeTimingMode` at all and always returned the recorded-pace ratio.
- `getJourneyElevationData()` derived `segmentProgress` from `segmentPointOffset / (segmentPointCount - 1)` and then mapped that point-index fraction into the *distance* span (`distanceStartRatio` … `distanceEndRatio`).

The error is zero when recording density is uniform and grows with the variation in points per kilometre. On a climb — slow uphill, many points per km; fast downhill, few — a summit sits at 0.50 by distance but at 0.80 by point index. Found on an out-and-back mountain ride: the summit photo appeared about 54 seconds late in a 3-minute video, and the elevation chart peaked while the marker was already well into the descent. The stats overlay, which reads distance, agreed with the marker.

Both now derive progress from cumulative distance in `'uniform'` mode and keep their existing behaviour in `'recorded'` mode.

`journeyUtils.ts` already carried a comment warning against exactly this ("Never use raw coordinate count here … The elevation chart must share the same horizontal scale as replay progress") — it applied to the `distance` field, but the `progress` field beside it came from the same point-index fraction.

## Placement was also frozen at import time

A photo's `progress` is computed once, when the photo is added. Switching Route Pace afterwards, or loading a saved project, kept whichever ruler was active at import. `usePictureRouteSync` recomputes GPS- and timestamp-placed photos from their stored coordinates whenever the route, the segment order or the timing mode changes. Manually placed photos are left alone.

The recomputation deliberately does **not** depend on the picture list itself: on an out-and-back route the nearest-segment match can flip between the outbound and the return leg, and driving the effect from the list it writes to would loop. It runs once per route/mode change and is skipped during an export.

New tests in `photoPlacementDistance.test.ts` cover the density case, the mode switch after import, and idempotence of the recomputation.

## Checks

- `npm --prefix app run lint` — clean
- `npm --prefix app run test:run` — 136 tests pass
- `tsc -b` — clean
- Verified on the original ride: the summit photo now appears at the summit, in step with the elevation profile and the stats overlay.