### PR TITLE
Keep the follow camera on the marker over terrain, and stop the stats overlay resizing

### DIFF
--- a/app/src/components/map/hooks/useTrailPlaybackCamera.ts
+++ b/app/src/components/map/hooks/useTrailPlaybackCamera.ts
@@ -263,12 +263,44 @@ export function useTrailPlaybackCamera({
       const newZoom = smoothZoom(currentZoom, targetPose.zoom);
       const newPitch = smoothPitch(mapRef.current.getPitch(), targetPose.pitch);
 
+      // With 3D terrain the marker is drawn on the terrain surface, while the
+      // camera aims at the centre point's elevation. MapLibre normally keeps
+      // that elevation clamped to the terrain for us — but it stops doing so
+      // for the rest of the session as soon as any `easeTo` has run with
+      // terrain enabled (`_elevationFreeze` is only cleared for eases that
+      // pass `freezeElevation`), and `jumpTo` never updates it at all. The
+      // replay camera eases every frame and the export jumps every frame, so
+      // the centre stays pinned at whatever elevation it last had while the
+      // marker climbs away from it: on a summit the marker leaves the top of
+      // the frame, and the error grows with altitude. Pass the elevation
+      // explicitly with the rest of the pose. `queryTerrainElevation` already
+      // includes the terrain exaggeration and returns null when terrain is
+      // off, in which case we leave the elevation alone.
+      const terrainElevation = mapRef.current.queryTerrainElevation([
+        currentPosition.lon,
+        currentPosition.lat,
+      ]);
+      const centerElevation = typeof terrainElevation === 'number' && Number.isFinite(terrainElevation)
+        ? { elevation: terrainElevation }
+        : {};
+
+      // `easeTo` ignores an elevation passed in options - it derives its own
+      // target from the terrain and interpolates toward it, which lags behind
+      // on a continuous climb because every frame replaces the previous ease
+      // before it finishes. Setting it here first makes the eased path start
+      // from the correct height as well.
+      if (centerElevation.elevation !== undefined
+        && Math.abs(mapRef.current.transform.elevation - centerElevation.elevation) > 0.25) {
+        mapRef.current.setCenterElevation(centerElevation.elevation);
+      }
+
       // During deterministic export, camera interpolation must not run on its
       // own clock. The exporter advances playback one frame at a time and waits
       // for this exact pose to render before encoding it.
       if (isDeterministicExport) {
         mapRef.current.jumpTo({
           ...targetPose,
+          ...centerElevation,
           center: [currentPosition.lon, currentPosition.lat],
           zoom: cameraMode === 'follow' ? targetPose.zoom : newZoom,
           pitch: cameraMode === 'follow' ? targetPose.pitch : newPitch,
@@ -277,11 +309,13 @@ export function useTrailPlaybackCamera({
       } else if (cameraMode === 'follow') {
         mapRef.current.easeTo({
           ...targetPose,
+          ...centerElevation,
           center: [currentPosition.lon, currentPosition.lat],
           duration: 100,
         });
       } else {
         mapRef.current.easeTo({
+          ...centerElevation,
           center: [currentPosition.lon, currentPosition.lat],
           zoom: newZoom,
           pitch: newPitch,

--- a/app/src/components/stats/StatsOverlay.tsx
+++ b/app/src/components/stats/StatsOverlay.tsx
@@ -178,6 +178,44 @@ export function StatsOverlay({ compact = false, layout = 'default', variant = 'd
     };
   }, [currentPosition, playback, totalDistance, computeRealElapsedAtProgress, segmentTimings, activeTrack, computedJourney]);
 
+  /**
+   * Breite, die jede Kachel dauerhaft freihaelt.
+   *
+   * Die Box richtete sich bisher nach dem gerade angezeigten Text. Aus "0:00"
+   * wird "42:28", aus "345 m" wird "1018 m" - jede zusaetzliche Ziffer machte
+   * die Box breiter, und sie zappelte waehrend der ganzen Wiedergabe. Am
+   * Anfang war sie ausserdem unangenehm schmal.
+   *
+   * Die Endwerte der Tour stehen aber von vornherein fest. Wir halten deshalb
+   * gleich zu Beginn so viel Platz frei, wie der breiteste Wert spaeter
+   * braucht. Tempo und Puls bleiben aussen vor: Fuer sie gibt es keinen
+   * verlaesslichen Hoechstwert, ihre Texte sind aber ohnehin gleich lang.
+   */
+  const reserveValues = useMemo<Partial<Record<StatId, string>>>(() => {
+    const journeyTrackIds = new Set(
+      segmentTimings
+        .filter((timing) => timing.type === 'track' && timing.trackId)
+        .map((timing) => timing.trackId as string),
+    );
+    const journeyTracks = journeyTrackIds.size > 0
+      ? tracks.filter((track) => journeyTrackIds.has(track.id))
+      : activeTrack
+        ? [activeTrack]
+        : [];
+
+    const totalElevationGain = journeyTracks.reduce((sum, track) => sum + (track.elevationGain || 0), 0);
+    const highestPoint = journeyTracks.reduce((highest, track) => Math.max(highest, track.maxElevation || 0), 0);
+    const fastest = journeyTracks.reduce((highest, track) => Math.max(highest, track.maxSpeed || 0), 0);
+
+    return {
+      duration: formatStatsDuration(computeRealElapsedAtProgress(1)),
+      distance: formatDistance(totalDistance, settings.unitSystem),
+      elevation: formatElevation(totalElevationGain, settings.unitSystem),
+      altitude: formatElevation(highestPoint, settings.unitSystem),
+      speed: formatSpeedFromKmh(fastest, settings.unitSystem),
+    };
+  }, [activeTrack, computeRealElapsedAtProgress, segmentTimings, settings.unitSystem, totalDistance, tracks]);
+
   if (!currentStats || journeySegments.length === 0) return null;
 
   const iconCls = isExportVariant ? 'w-3 h-3 text-white' : isNarrowLayout ? 'w-3.5 h-3.5 text-white' : 'w-4 h-4 text-white';
@@ -263,6 +301,7 @@ export function StatsOverlay({ compact = false, layout = 'default', variant = 'd
             icon={stat.icon}
             label={stat.label}
             value={stat.value!}
+            reserve={reserveValues[stat.id]}
             compact={isNarrowLayout}
             exportCompact={isExportVariant}
           />
@@ -285,11 +324,13 @@ interface StatItemProps {
   icon: React.ReactNode;
   label: string;
   value: string;
+  /** Breitester Text, den diese Kachel im Lauf der Tour zeigen wird. */
+  reserve?: string;
   compact?: boolean;
   exportCompact?: boolean;
 }
 
-function StatItem({ icon, label, value, compact = false, exportCompact = false }: StatItemProps) {
+function StatItem({ icon, label, value, reserve, compact = false, exportCompact = false }: StatItemProps) {
   return (
     <div className={`min-w-max text-center ${exportCompact ? 'px-0.5 py-0.5' : compact ? 'px-1 py-0.5' : 'px-1 py-0.5'}`}>
       <div className={`flex items-center justify-center min-w-0 ${
@@ -307,12 +348,20 @@ function StatItem({ icon, label, value, compact = false, exportCompact = false }
         </span>
       </div>
       <div
-        className={`tr-stat-value flex min-h-[1.2rem] items-center justify-center whitespace-nowrap px-0.5 text-center font-semibold tabular-nums tracking-[-0.03em] ${
+        className={`tr-stat-value grid min-h-[1.2rem] items-center justify-items-center whitespace-nowrap px-0.5 text-center font-semibold tabular-nums tracking-[-0.03em] ${
           exportCompact ? 'text-[9px] leading-[1.05] text-white' : compact ? 'text-[11px] leading-[1.1]' : 'text-[12px] leading-[1.1]'
         }`}
         title={value}
       >
-        {value}
+        {/* Haelt die Breite des spaeteren Hoechstwerts frei, damit die Box
+            waehrend der Wiedergabe nicht mitwaechst. Liegt in derselben
+            Rasterzelle wie der Wert und ist unsichtbar. */}
+        {reserve && (
+          <span aria-hidden className="invisible col-start-1 row-start-1">
+            {reserve}
+          </span>
+        )}
+        <span className="col-start-1 row-start-1">{value}</span>
       </div>
     </div>
   );


### PR DESCRIPTION
<html>
<body>
<!--StartFragment--><p dir="ltr">Two independent fixes, one commit each. Both turned up while replaying an
out-and-back mountain ride with the close follow-behind preset.</p>

<h2 dir="ltr">1. The follow camera loses the marker over 3D terrain</h2>

<p dir="ltr">With 3D terrain the marker is drawn on the terrain surface, while the camera
aims at the centre point's elevation. MapLibre normally keeps that elevation
clamped to the terrain, but:</p>

<ul dir="ltr">
<li><code>_elevationFreeze</code> is set by every <code>easeTo</code> that runs with terrain enabled
and is only cleared for eases that pass <code>freezeElevation</code>. The replay camera
eases on every frame, so after the first frame the automatic clamping stays
off for the rest of the session.</li>
<li><code>jumpTo</code> — the deterministic export path — never updates the centre
elevation at all.</li>
</ul>

<p dir="ltr">The centre therefore stays pinned at whatever elevation it last had while the
marker climbs away from it. The offset grows with altitude: near the summit
the marker leaves the top of the frame entirely. Turning 3D terrain off makes
it disappear, which is what pointed at the cause.</p>

<p dir="ltr">The camera now passes the terrain elevation under the marker explicitly with
the rest of the pose. <code>queryTerrainElevation</code> already includes the terrain
exaggeration and returns <code>null</code> when terrain is off, in which case the
elevation is left alone.</p>

<p dir="ltr">Measured in a browser against a synthetic ramp rising from 300 m to 1150 m,
stepping the camera up the slope the way the exporter does:</p>

<div dir="ltr">
  | camera elevation | marker off centre
-- | -- | --
before | stuck at 1725 m | up to 223 px
after | tracks the terrain, 450 → 1491 m | centred at every step

</div>

<p dir="ltr">Note that <code>calculateTerrainAwareAdjustments()</code> currently widens the view and
flattens the pitch as a route climbs (up to 2 zoom levels and 15°), which
reads as an attempt to compensate for this. With the cause removed that
correction could probably be reduced, giving the close presets back their
close framing on climbs. Happy to look at that separately if you agree.</p>

<h2 dir="ltr">2. The stats overlay resizes while the replay runs</h2>

<p dir="ltr">The overlay is only as wide as the text currently in it. <code>0:00</code> becomes
<code>42:28</code>, <code>345 m</code> becomes <code>1018 m</code>, and every extra digit widens the box, so it
twitches throughout the replay and is uncomfortably narrow at the start.</p>

<p dir="ltr">The values already use <code>tabular-nums</code>, so digits don't jitter — but the
character count still changes.</p>

<p dir="ltr">The final values of a route are known up front, so each tile now reserves the
width of the widest value it will ever show: total duration, total distance,
total gain, highest point, top speed. Pace and heart rate are left out, as
there is no reliable maximum for them and their text length barely varies.</p>

<p dir="ltr">The reservation is a hidden sizing span in the same grid cell as the value.
Verified against html2canvas 1.4.1, which rasterises the overlay for the
export: the tile grows from 60 px to 84 px while the drawn pixel count is
identical, so the reserved text is not painted into the video.</p>

<h2 dir="ltr">Checks</h2>

<ul dir="ltr">
<li><code>npm --prefix app run lint</code> — clean</li>
<li><code>npm --prefix app run test:run</code> — all tests pass</li>
<li><code>tsc -b</code> — clean</li>
<li>Verified in the app on the route both were found on.</li></ul><!--EndFragment-->
</body>
</html>