### PR TITLE
fix: keep landmarks API requests same-origin on www

### DIFF
--- a/app/src/utils/pagesMiddleware.test.js
+++ b/app/src/utils/pagesMiddleware.test.js
@@ -1,0 +1,30 @@
+import { describe, expect, it, vi } from 'vitest';
+import { onRequest } from '../../../functions/_middleware.js';
+
+describe('Pages hostname middleware', () => {
+  it('keeps www API requests on their original same-origin hostname', async () => {
+    const downstream = new Response('api response');
+    const next = vi.fn().mockResolvedValue(downstream);
+
+    const response = await onRequest({
+      request: new Request('https://www.trailreplay.com/api/landmarks', { method: 'POST' }),
+      next,
+    });
+
+    expect(response).toBe(downstream);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('still redirects www page requests to the canonical apex hostname', async () => {
+    const next = vi.fn();
+
+    const response = await onRequest({
+      request: new Request('https://www.trailreplay.com/tutorial?source=test'),
+      next,
+    });
+
+    expect(response.status).toBe(301);
+    expect(response.headers.get('Location')).toBe('https://trailreplay.com/tutorial?source=test');
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/functions/_middleware.js
+++ b/functions/_middleware.js
@@ -3,7 +3,11 @@
 // impressions/clicks across duplicate URLs for the same pages.
 export async function onRequest({ request, next }) {
   const url = new URL(request.url);
-  if (url.hostname === 'www.trailreplay.com') {
+  // Keep API calls on the hostname that served the app. Redirecting a POST
+  // from www to the apex turns a same-origin request into a cross-origin one
+  // (and a 301 may also rewrite it to GET) before the Pages Function can add
+  // its response headers.
+  if (url.hostname === 'www.trailreplay.com' && !url.pathname.startsWith('/api/')) {
     url.hostname = 'trailreplay.com';
     return Response.redirect(url.toString(), 301);
   }


### PR DESCRIPTION
## Summary

- bypass the `www` → apex SEO redirect for `/api/*` requests
- keep the landmarks POST on the same origin as the app
- retain canonical redirects for ordinary page requests
- add regression coverage for both API and page routing

## Production diagnosis

`https://www.trailreplay.com/api/landmarks` currently returns a `301` to `https://trailreplay.com/api/landmarks` before the Pages Function runs. That converts the app's same-origin POST into a cross-origin redirect and can rewrite POST to GET, producing the reported CORS failure. The apex endpoint itself responds with the expected CORS header.

## Verification

- `npm --prefix app run lint` (no errors; one existing hook warning)
- `npm --prefix app run test:run` (36 files, 142 tests passed)
- `cd app && npx tsc -b`
- `git diff --check`