### PR TITLE
Fix video schema and add cinematic follow-camera stability

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -93,11 +93,6 @@
             "@type": "DigitalDocument",
             "name": "GPX File",
             "encodingFormat": "application/gpx+xml"
-          },
-          "result": {
-            "@type": "VideoObject",
-            "name": "Animated Trail Video",
-            "encodingFormat": "video/mp4"
           }
         }
       }

--- a/app/scripts/validate-seo-output.mjs
+++ b/app/scripts/validate-seo-output.mjs
@@ -30,8 +30,42 @@ function visibleWordCount(html) {
     .length;
 }
 
+function validateVideoObjects(value, file, location = '$') {
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => validateVideoObjects(item, file, `${location}[${index}]`));
+    return;
+  }
+
+  if (!value || typeof value !== 'object') return;
+
+  const types = Array.isArray(value['@type']) ? value['@type'] : [value['@type']];
+  if (types.includes('VideoObject')) {
+    for (const property of ['name', 'thumbnailUrl', 'uploadDate']) {
+      if (!value[property]) {
+        failures.push(`${file} has a VideoObject at ${location} without required ${property}`);
+      }
+    }
+  }
+
+  for (const [property, child] of Object.entries(value)) {
+    validateVideoObjects(child, file, `${location}.${property}`);
+  }
+}
+
+function validateStructuredData(html, file) {
+  const scriptPattern = /<script\b[^>]*type=["']application\/ld\+json["'][^>]*>([\s\S]*?)<\/script>/gi;
+  for (const match of html.matchAll(scriptPattern)) {
+    try {
+      validateVideoObjects(JSON.parse(match[1]), file);
+    } catch (error) {
+      failures.push(`${file} contains invalid JSON-LD: ${error.message}`);
+    }
+  }
+}
+
 for (const { file, canonical } of requiredDocuments) {
   const html = await readFile(path.join(distRoot, file), 'utf8');
+  validateStructuredData(html, file);
   if (!html.includes('<title>')) failures.push(`${file} is missing a title`);
   if (!html.includes(`rel="canonical" href="${canonical}"`)) {
     failures.push(`${file} is missing canonical ${canonical}`);

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -469,10 +469,20 @@ function App() {
                   }}
                   onMouseDown={handleStatsDragStart}
                 >
-                  <StatsOverlay
-                    layout={statsShouldUseNarrowLayout ? 'narrow' : 'default'}
-                    variant={activeExportCropMetrics ? 'export' : 'default'}
-                  />
+                  <div
+                    data-stats-scale-wrapper
+                    style={{
+                      transform: `scale(${settings.statsScale})`,
+                      transformOrigin: settings.statsPosition || !statsShouldUseNarrowLayout
+                        ? 'top left'
+                        : 'top center',
+                    }}
+                  >
+                    <StatsOverlay
+                      layout={statsShouldUseNarrowLayout ? 'narrow' : 'default'}
+                      variant={activeExportCropMetrics ? 'export' : 'default'}
+                    />
+                  </div>
                 </div>
               )}
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -36,12 +36,28 @@ function isNarrowFrame(width: number, height: number) {
   return width <= height || width < 560;
 }
 
+type StatsResizeCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
+
+interface StatsResizeStart {
+  corner: StatsResizeCorner;
+  mouseX: number;
+  mouseY: number;
+  width: number;
+  height: number;
+  left: number;
+  top: number;
+  scale: number;
+}
+
 function App() {
   const { t } = useI18n();
   const mapContainerRef = useRef<HTMLDivElement>(null);
   const fileInputRef = useRef<HTMLInputElement>(null);
+  const statsScaleWrapperRef = useRef<HTMLDivElement>(null);
   const statsDragStartRef = useRef<{ mouseX: number; mouseY: number; startX: number; startY: number } | null>(null);
+  const statsResizeStartRef = useRef<StatsResizeStart | null>(null);
   const [isDraggingStats, setIsDraggingStats] = useState(false);
+  const [isResizingStats, setIsResizingStats] = useState(false);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showInfoPanel, setShowInfoPanel] = useState(false);
   const [isMapReady, setIsMapReady] = useState(false);
@@ -201,6 +217,9 @@ function App() {
   const statsShouldUseNarrowLayout = activeExportCropMetrics
     ? isNarrowFrame(activeExportCropMetrics.frameWidth, activeExportCropMetrics.frameHeight)
     : isNarrowScreen;
+  const resolvedStatsLayout = settings.statsLayout === 'auto'
+    ? statsShouldUseNarrowLayout ? 'narrow' : 'default'
+    : settings.statsLayout;
 
   const statsOverlayStyle = (() => {
     if (settings.statsPosition) {
@@ -269,6 +288,36 @@ function App() {
     setIsDraggingStats(true);
   }, [settings.statsPosition]);
 
+  const handleStatsResizeStart = useCallback((e: React.MouseEvent, corner: StatsResizeCorner) => {
+    e.preventDefault();
+    e.stopPropagation();
+    const wrapper = statsScaleWrapperRef.current;
+    const container = mapContainerRef.current;
+    if (!wrapper || !container) return;
+
+    const rect = wrapper.getBoundingClientRect();
+    const containerRect = container.getBoundingClientRect();
+    // Materialize the automatic starting position so resizing keeps the
+    // panel's visible top-left corner stable.
+    setSettings({
+      statsPosition: {
+        x: Math.max(0, Math.min(1, (rect.left - containerRect.left) / containerRect.width)),
+        y: Math.max(0, Math.min(1, (rect.top - containerRect.top) / containerRect.height)),
+      },
+    });
+    statsResizeStartRef.current = {
+      corner,
+      mouseX: e.clientX,
+      mouseY: e.clientY,
+      width: rect.width,
+      height: rect.height,
+      left: rect.left - containerRect.left,
+      top: rect.top - containerRect.top,
+      scale: settings.statsScale,
+    };
+    setIsResizingStats(true);
+  }, [setSettings, settings.statsScale]);
+
   useEffect(() => {
     if (!isDraggingStats) return;
     const onMove = (e: MouseEvent) => {
@@ -289,6 +338,47 @@ function App() {
     window.addEventListener('mouseup', onUp);
     return () => { window.removeEventListener('mousemove', onMove); window.removeEventListener('mouseup', onUp); };
   }, [isDraggingStats, setSettings]);
+
+  useEffect(() => {
+    if (!isResizingStats) return;
+    const onMove = (e: MouseEvent) => {
+      const container = mapContainerRef.current;
+      const start = statsResizeStartRef.current;
+      if (!container || !start) return;
+
+      const containerRect = container.getBoundingClientRect();
+      const dx = e.clientX - start.mouseX;
+      const dy = e.clientY - start.mouseY;
+      const fromLeft = start.corner.includes('left');
+      const fromTop = start.corner.includes('top');
+      const width = Math.max(72, start.width + (fromLeft ? -dx : dx));
+      const height = Math.max(52, start.height + (fromTop ? -dy : dy));
+      const areaRatio = (width * height) / Math.max(1, start.width * start.height);
+      const scale = Math.max(0.6, Math.min(2, start.scale * Math.sqrt(areaRatio)));
+      const layout = width >= height ? 'horizontal' : 'vertical';
+      const left = fromLeft ? start.left + start.width - width : start.left;
+      const top = fromTop ? start.top + start.height - height : start.top;
+
+      setSettings({
+        statsScale: Math.round(scale * 100) / 100,
+        statsLayout: layout,
+        statsPosition: {
+          x: Math.max(0, Math.min(0.98, left / containerRect.width)),
+          y: Math.max(0, Math.min(0.98, top / containerRect.height)),
+        },
+      });
+    };
+    const onUp = () => {
+      statsResizeStartRef.current = null;
+      setIsResizingStats(false);
+    };
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+    return () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+    };
+  }, [isResizingStats, setSettings]);
 
   useEffect(() => {
     return () => {
@@ -461,17 +551,20 @@ function App() {
               {/* Stats Overlay */}
               {hasTracks && (
                 <div
-                  className="absolute z-10"
+                  className="group absolute z-10"
                   style={{
                     ...statsOverlayStyle,
-                    cursor: isDraggingStats ? 'grabbing' : 'grab',
+                    cursor: isDraggingStats ? 'grabbing' : isResizingStats ? 'default' : 'grab',
                     userSelect: 'none',
                   }}
                   onMouseDown={handleStatsDragStart}
                 >
                   <div
+                    ref={statsScaleWrapperRef}
                     data-stats-scale-wrapper
                     style={{
+                      position: 'relative',
+                      width: 'fit-content',
                       transform: `scale(${settings.statsScale})`,
                       transformOrigin: settings.statsPosition || !statsShouldUseNarrowLayout
                         ? 'top left'
@@ -479,9 +572,27 @@ function App() {
                     }}
                   >
                     <StatsOverlay
-                      layout={statsShouldUseNarrowLayout ? 'narrow' : 'default'}
+                      layout={resolvedStatsLayout}
                       variant={activeExportCropMetrics ? 'export' : 'default'}
                     />
+                    {!isExporting && (['top-left', 'top-right', 'bottom-left', 'bottom-right'] as const).map((corner) => {
+                      const vertical = corner.startsWith('top') ? 'top-[-5px]' : 'bottom-[-5px]';
+                      const horizontal = corner.endsWith('left') ? 'left-[-5px]' : 'right-[-5px]';
+                      const cursor = corner === 'top-left' || corner === 'bottom-right'
+                        ? 'cursor-nwse-resize'
+                        : 'cursor-nesw-resize';
+                      return (
+                        <button
+                          key={corner}
+                          type="button"
+                          aria-label="Resize stats"
+                          className={`absolute ${vertical} ${horizontal} ${cursor} z-20 h-3 w-3 rounded-full border-2 border-white bg-[var(--evergreen)] shadow-md transition-opacity ${
+                            isResizingStats ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'
+                          }`}
+                          onMouseDown={(event) => handleStatsResizeStart(event, corner)}
+                        />
+                      );
+                    })}
                   </div>
                 </div>
               )}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -36,6 +36,23 @@ function isNarrowFrame(width: number, height: number) {
   return width <= height || width < 560;
 }
 
+function chooseStatsColumns(width: number, height: number, statCount: number) {
+  const count = Math.max(1, statCount);
+  const targetRatio = Math.max(0.1, width / Math.max(1, height));
+  let bestColumns = 1;
+  let bestScore = Number.POSITIVE_INFINITY;
+  for (let columns = 1; columns <= count; columns += 1) {
+    const rows = Math.ceil(count / columns);
+    const gridRatio = columns / rows;
+    const score = Math.abs(Math.log(targetRatio / gridRatio));
+    if (score < bestScore) {
+      bestScore = score;
+      bestColumns = columns;
+    }
+  }
+  return bestColumns;
+}
+
 type StatsResizeCorner = 'top-left' | 'top-right' | 'bottom-left' | 'bottom-right';
 
 interface StatsResizeStart {
@@ -217,7 +234,9 @@ function App() {
   const statsShouldUseNarrowLayout = activeExportCropMetrics
     ? isNarrowFrame(activeExportCropMetrics.frameWidth, activeExportCropMetrics.frameHeight)
     : isNarrowScreen;
-  const resolvedStatsLayout = settings.statsLayout === 'auto'
+  const resolvedStatsLayout = settings.statsColumns !== null
+    ? statsShouldUseNarrowLayout ? 'narrow' : 'default'
+    : settings.statsLayout === 'auto'
     ? statsShouldUseNarrowLayout ? 'narrow' : 'default'
     : settings.statsLayout;
 
@@ -355,13 +374,14 @@ function App() {
       const height = Math.max(52, start.height + (fromTop ? -dy : dy));
       const areaRatio = (width * height) / Math.max(1, start.width * start.height);
       const scale = Math.max(0.6, Math.min(2, start.scale * Math.sqrt(areaRatio)));
-      const layout = width >= height ? 'horizontal' : 'vertical';
+      const columns = chooseStatsColumns(width, height, settings.visibleStats.length);
       const left = fromLeft ? start.left + start.width - width : start.left;
       const top = fromTop ? start.top + start.height - height : start.top;
 
       setSettings({
         statsScale: Math.round(scale * 100) / 100,
-        statsLayout: layout,
+        statsLayout: 'auto',
+        statsColumns: columns,
         statsPosition: {
           x: Math.max(0, Math.min(0.98, left / containerRect.width)),
           y: Math.max(0, Math.min(0.98, top / containerRect.height)),
@@ -378,7 +398,7 @@ function App() {
       window.removeEventListener('mousemove', onMove);
       window.removeEventListener('mouseup', onUp);
     };
-  }, [isResizingStats, setSettings]);
+  }, [isResizingStats, setSettings, settings.visibleStats.length]);
 
   useEffect(() => {
     return () => {
@@ -566,6 +586,8 @@ function App() {
                       position: 'relative',
                       width: 'fit-content',
                       transform: `scale(${settings.statsScale})`,
+                      outline: isResizingStats ? '1px dashed rgba(255,255,255,0.8)' : undefined,
+                      outlineOffset: isResizingStats ? '4px' : undefined,
                       transformOrigin: settings.statsPosition || !statsShouldUseNarrowLayout
                         ? 'top left'
                         : 'top center',

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -66,6 +66,14 @@ interface StatsResizeStart {
   scale: number;
 }
 
+interface StatsResizeGuide {
+  corner: StatsResizeCorner;
+  left: number;
+  top: number;
+  width: number;
+  height: number;
+}
+
 function App() {
   const { t } = useI18n();
   const mapContainerRef = useRef<HTMLDivElement>(null);
@@ -75,6 +83,7 @@ function App() {
   const statsResizeStartRef = useRef<StatsResizeStart | null>(null);
   const [isDraggingStats, setIsDraggingStats] = useState(false);
   const [isResizingStats, setIsResizingStats] = useState(false);
+  const [statsResizeGuide, setStatsResizeGuide] = useState<StatsResizeGuide | null>(null);
   const [isFullscreen, setIsFullscreen] = useState(false);
   const [showInfoPanel, setShowInfoPanel] = useState(false);
   const [isMapReady, setIsMapReady] = useState(false);
@@ -248,6 +257,27 @@ function App() {
         ? previewStatCount
         : statsShouldUseNarrowLayout ? Math.min(previewStatCount, 2) : Math.min(previewStatCount, 4);
   const previewColumnOptions = Array.from({ length: previewStatCount }, (_, index) => index + 1);
+  const resizeGuideTargets = statsResizeGuide
+    ? previewColumnOptions.map((columns) => {
+      const rows = Math.ceil(previewStatCount / columns);
+      const ratio = columns / rows;
+      const area = statsResizeGuide.width * statsResizeGuide.height;
+      const targetWidth = Math.sqrt(area * ratio);
+      const targetHeight = Math.sqrt(area / ratio);
+      const fromLeft = statsResizeGuide.corner.includes('left');
+      const fromTop = statsResizeGuide.corner.includes('top');
+      const anchorRight = statsResizeGuide.left + statsResizeGuide.width;
+      const anchorBottom = statsResizeGuide.top + statsResizeGuide.height;
+      const targetLeft = fromLeft ? anchorRight - targetWidth : statsResizeGuide.left;
+      const targetTop = fromTop ? anchorBottom - targetHeight : statsResizeGuide.top;
+      return {
+        columns,
+        rows,
+        handleX: fromLeft ? targetLeft : targetLeft + targetWidth,
+        handleY: fromTop ? targetTop : targetTop + targetHeight,
+      };
+    })
+    : [];
 
   const statsOverlayStyle = (() => {
     if (settings.statsPosition) {
@@ -343,6 +373,13 @@ function App() {
       top: rect.top - containerRect.top,
       scale: settings.statsScale,
     };
+    setStatsResizeGuide({
+      corner,
+      left: rect.left - containerRect.left,
+      top: rect.top - containerRect.top,
+      width: rect.width,
+      height: rect.height,
+    });
     setIsResizingStats(true);
   }, [setSettings, settings.statsScale]);
 
@@ -399,6 +436,7 @@ function App() {
     };
     const onUp = () => {
       statsResizeStartRef.current = null;
+      setStatsResizeGuide(null);
       setIsResizingStats(false);
     };
     window.addEventListener('mousemove', onMove);
@@ -646,6 +684,24 @@ function App() {
                       );
                     })}
                   </div>
+                </div>
+              )}
+
+              {isResizingStats && statsResizeGuide && (
+                <div aria-hidden="true" className="pointer-events-none absolute inset-0 z-20">
+                  {resizeGuideTargets.map((target) => (
+                    <div
+                      key={`${target.columns}-${target.rows}`}
+                      className={`absolute -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-md border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide shadow-lg ${
+                        target.columns === previewColumns
+                          ? 'border-[var(--evergreen)] bg-[var(--evergreen)] text-[var(--canvas)]'
+                          : 'border-white/35 bg-[rgba(9,14,19,0.88)] text-white/75'
+                      }`}
+                      style={{ left: target.handleX, top: target.handleY }}
+                    >
+                      {target.columns} × {target.rows}
+                    </div>
+                  ))}
                 </div>
               )}
 

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -247,7 +247,7 @@ function App() {
       : settings.statsLayout === 'horizontal'
         ? previewStatCount
         : statsShouldUseNarrowLayout ? Math.min(previewStatCount, 2) : Math.min(previewStatCount, 4);
-  const previewRows = Math.ceil(previewStatCount / previewColumns);
+  const previewColumnOptions = Array.from({ length: previewStatCount }, (_, index) => index + 1);
 
   const statsOverlayStyle = (() => {
     if (settings.statsPosition) {
@@ -605,18 +605,22 @@ function App() {
                     {isResizingStats && (
                       <div
                         aria-hidden="true"
-                        className="pointer-events-none absolute inset-0 z-30 grid overflow-hidden rounded-[inherit] border-2 border-dashed border-white/80 bg-white/[0.04]"
-                        style={{
-                          gridTemplateColumns: `repeat(${previewColumns}, minmax(0, 1fr))`,
-                          gridTemplateRows: `repeat(${previewRows}, minmax(0, 1fr))`,
-                        }}
+                        className="pointer-events-none absolute left-0 top-[-42px] z-30 flex w-max max-w-[min(90vw,520px)] gap-1 rounded-lg border border-white/20 bg-[rgba(9,14,19,0.94)] p-1 shadow-lg"
                       >
-                        {Array.from({ length: previewStatCount }, (_, index) => (
-                          <div
-                            key={index}
-                            className="border border-dashed border-white/35"
-                          />
-                        ))}
+                        {previewColumnOptions.map((columns) => {
+                          const rows = Math.ceil(previewStatCount / columns);
+                          const active = columns === previewColumns;
+                          return (
+                            <div
+                              key={columns}
+                              className={`whitespace-nowrap rounded-md px-2 py-1 text-[10px] font-semibold uppercase tracking-wide transition-colors ${
+                                active ? 'bg-[var(--evergreen)] text-[var(--canvas)]' : 'text-white/65'
+                              }`}
+                            >
+                              {columns} × {rows}
+                            </div>
+                          );
+                        })}
                       </div>
                     )}
                     <StatsOverlay

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -239,6 +239,15 @@ function App() {
     : settings.statsLayout === 'auto'
     ? statsShouldUseNarrowLayout ? 'narrow' : 'default'
     : settings.statsLayout;
+  const previewStatCount = Math.max(1, settings.visibleStats.length);
+  const previewColumns = settings.statsColumns !== null
+    ? Math.max(1, Math.min(previewStatCount, Math.round(settings.statsColumns)))
+    : settings.statsLayout === 'vertical'
+      ? 1
+      : settings.statsLayout === 'horizontal'
+        ? previewStatCount
+        : statsShouldUseNarrowLayout ? Math.min(previewStatCount, 2) : Math.min(previewStatCount, 4);
+  const previewRows = Math.ceil(previewStatCount / previewColumns);
 
   const statsOverlayStyle = (() => {
     if (settings.statsPosition) {
@@ -593,6 +602,23 @@ function App() {
                         : 'top center',
                     }}
                   >
+                    {isResizingStats && (
+                      <div
+                        aria-hidden="true"
+                        className="pointer-events-none absolute inset-0 z-30 grid overflow-hidden rounded-[inherit] border-2 border-dashed border-white/80 bg-white/[0.04]"
+                        style={{
+                          gridTemplateColumns: `repeat(${previewColumns}, minmax(0, 1fr))`,
+                          gridTemplateRows: `repeat(${previewRows}, minmax(0, 1fr))`,
+                        }}
+                      >
+                        {Array.from({ length: previewStatCount }, (_, index) => (
+                          <div
+                            key={index}
+                            className="border border-dashed border-white/35"
+                          />
+                        ))}
+                      </div>
+                    )}
                     <StatsOverlay
                       layout={resolvedStatsLayout}
                       variant={activeExportCropMetrics ? 'export' : 'default'}

--- a/app/src/App.tsx
+++ b/app/src/App.tsx
@@ -273,8 +273,10 @@ function App() {
       return {
         columns,
         rows,
-        handleX: fromLeft ? targetLeft : targetLeft + targetWidth,
-        handleY: fromTop ? targetTop : targetTop + targetHeight,
+        left: targetLeft,
+        top: targetTop,
+        width: targetWidth,
+        height: targetHeight,
       };
     })
     : [];
@@ -692,12 +694,17 @@ function App() {
                   {resizeGuideTargets.map((target) => (
                     <div
                       key={`${target.columns}-${target.rows}`}
-                      className={`absolute -translate-x-1/2 -translate-y-1/2 whitespace-nowrap rounded-md border px-2 py-1 text-[10px] font-semibold uppercase tracking-wide shadow-lg ${
+                      className={`absolute flex items-center justify-center rounded-lg border-2 border-dashed text-[10px] font-semibold uppercase tracking-wide shadow-lg transition-colors ${
                         target.columns === previewColumns
-                          ? 'border-[var(--evergreen)] bg-[var(--evergreen)] text-[var(--canvas)]'
-                          : 'border-white/35 bg-[rgba(9,14,19,0.88)] text-white/75'
+                          ? 'border-[var(--evergreen)] bg-[var(--evergreen)]/20 text-white'
+                          : 'border-white/30 bg-white/[0.03] text-white/65'
                       }`}
-                      style={{ left: target.handleX, top: target.handleY }}
+                      style={{
+                        left: target.left,
+                        top: target.top,
+                        width: target.width,
+                        height: target.height,
+                      }}
                     >
                       {target.columns} × {target.rows}
                     </div>

--- a/app/src/components/map/MapElevationProfile.tsx
+++ b/app/src/components/map/MapElevationProfile.tsx
@@ -3,6 +3,7 @@ import { useAppStore } from '@/store/useAppStore';
 import { useComputedJourney } from '@/hooks/useComputedJourney';
 import { convertElevation } from '@/utils/units';
 import type { CropPreviewMetrics } from '@/utils/crop';
+import { getElevationAtProgress } from './elevationProfile';
 
 interface MapElevationProfileProps {
   className?: string;
@@ -82,13 +83,6 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
       };
     });
 
-    // Create path for elevation profile (filled area from bottom)
-    let pathD = `M 0 ${svgHeight}`;
-    normalizedPoints.forEach((point) => {
-      pathD += ` L ${point.x} ${point.y}`;
-    });
-    pathD += ` L ${svgWidth} ${svgHeight} Z`;
-
     // Create segment paths with different colors
     const segmentPaths: Array<{
       pathD: string;
@@ -96,12 +90,19 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
       segmentIndex: number;
       type: 'track' | 'transport';
     }> = [];
+    const pointsBySegment = new Map<number, typeof normalizedPoints>();
+
+    normalizedPoints.forEach((point) => {
+      const points = pointsBySegment.get(point.segmentIndex) ?? [];
+      points.push(point);
+      pointsBySegment.set(point.segmentIndex, points);
+    });
 
     segmentTimings.forEach((timing) => {
       // Segment progress can share an exact boundary with the adjacent file.
       // Select by ownership, rather than by the boundary range, so separate
       // routes never become a fictitious climb or descent in the profile.
-      const segmentPoints = normalizedPoints.filter((p) => p.segmentIndex === timing.segmentIndex);
+      const segmentPoints = pointsBySegment.get(timing.segmentIndex) ?? [];
 
       if (segmentPoints.length > 1) {
         let segPathD = `M ${segmentPoints[0].x} ${svgHeight}`;
@@ -131,23 +132,22 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
     });
 
     return {
-      pathD,
-      minElevation,
-      maxElevation,
       svgWidth,
       svgHeight,
-      normalizedPoints,
+      pointsBySegment,
       segmentPaths,
     };
   }, [elevationData, segmentTimings, trailStyle.trailColor, tracks]);
 
-  // Calculate progress path (filled area showing progress)
+  // Only the clip width and interpolated label change during playback. The
+  // profile paths themselves stay static, avoiding a full GPX scan and a large
+  // SVG `d` string rebuild on every animation frame.
   const progressData = useMemo(() => {
     if (!profileData || playback.progress <= 0) {
-      return { pathD: '', currentElevation: 0, markerX: 0, markerY: 0, currentColor: trailStyle.trailColor };
+      return { currentElevation: 0, markerX: 0, currentColor: trailStyle.trailColor };
     }
 
-    const { svgWidth, svgHeight, normalizedPoints } = profileData;
+    const { svgWidth, pointsBySegment } = profileData;
     const progressX = playback.progress * svgWidth;
 
     // Find the current segment's color
@@ -156,62 +156,22 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
       currentColor = '#888888';
     }
 
-    // Profile points are distributed by journey timing/distance, not by raw
-    // GPX point count. Build a separate filled shape per completed segment so
-    // the progress paint never leaks into a later file.
-    const pointsBySegment = new Map<number, typeof normalizedPoints>();
-    normalizedPoints.forEach((point) => {
-      const points = pointsBySegment.get(point.segmentIndex) ?? [];
-      points.push(point);
-      pointsBySegment.set(point.segmentIndex, points);
-    });
-
-    let pathD = '';
-    let markerY = svgHeight;
-    let currentElevation = 0;
-
-    pointsBySegment.forEach((segmentPoints, segmentIndex) => {
-      const first = segmentPoints[0];
-      const last = segmentPoints[segmentPoints.length - 1];
-      if (!first || !last || playback.progress < first.progress) return;
-
-      const isCurrentSegment = segmentIndex === currentSegment?.segment.segmentIndex;
-      const isComplete = playback.progress >= last.progress;
-      const visiblePoints = isComplete
-        ? segmentPoints
-        : segmentPoints.filter((point) => point.progress <= playback.progress);
-      const pathPoints = [...visiblePoints];
-
-      if (!isComplete) {
-        const previous = visiblePoints[visiblePoints.length - 1] ?? first;
-        const next = segmentPoints.find((point) => point.progress > playback.progress);
-        if (next && next.progress > previous.progress) {
-          const ratio = (playback.progress - previous.progress) / (next.progress - previous.progress);
-          pathPoints.push({
-            ...previous,
-            x: progressX,
-            y: previous.y + (next.y - previous.y) * ratio,
-            elevation: previous.elevation + (next.elevation - previous.elevation) * ratio,
-            progress: playback.progress,
-          });
-        }
-      }
-
-      const endPoint = pathPoints[pathPoints.length - 1];
-      if (!endPoint) return;
-      pathD += ` M ${first.x} ${svgHeight}`;
-      pathPoints.forEach((point) => {
-        pathD += ` L ${point.x} ${point.y}`;
+    let currentPoints = currentSegment
+      ? pointsBySegment.get(currentSegment.segment.segmentIndex)
+      : undefined;
+    if (!currentPoints) {
+      currentPoints = [...pointsBySegment.values()].find((points) => {
+        const first = points[0];
+        const last = points[points.length - 1];
+        return first && last && playback.progress >= first.progress && playback.progress <= last.progress;
       });
-      pathD += ` L ${endPoint.x} ${svgHeight} Z`;
+    }
 
-      if (isCurrentSegment) {
-        markerY = endPoint.y;
-        currentElevation = endPoint.elevation;
-      }
-    });
+    const currentElevation = currentPoints
+      ? getElevationAtProgress(currentPoints, playback.progress)
+      : 0;
 
-    return { pathD, currentElevation, markerX: progressX, markerY, currentColor };
+    return { currentElevation, markerX: progressX, currentColor };
   }, [profileData, playback.progress, currentTrackColor, trailStyle.trailColor, isInTransport, currentSegment]);
 
   // The Style setting is the single source of truth for both preview and export.
@@ -224,7 +184,7 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
   }
 
   const { svgWidth, svgHeight, segmentPaths } = profileData;
-  const { pathD: progressPathD, currentElevation, markerX, currentColor } = progressData;
+  const { currentElevation, markerX, currentColor } = progressData;
   const elevUnit = settings.unitSystem === 'metric' ? 'm' : 'ft';
 
   const formattedCurrentElev = Math.round(convertElevation(currentElevation, settings.unitSystem));
@@ -262,6 +222,7 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
           preserveAspectRatio="none"
           className={`w-full ${isNonWideExportPreview ? 'h-[72px]' : 'h-[60px]'}`}
           id="elevationProfileSvg"
+          data-export-elevation-progress-color={currentColor}
         >
           {/* Gradient definitions for segments */}
           <defs>
@@ -282,6 +243,9 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
               <stop offset="0%" stopColor={currentColor} stopOpacity="0.9" />
               <stop offset="100%" stopColor={currentColor} stopOpacity="0.5" />
             </linearGradient>
+            <clipPath id="elevationProgressClip">
+              <rect x="0" y="0" width={markerX} height={svgHeight} />
+            </clipPath>
           </defs>
 
           {/* Background elevation profiles for each segment */}
@@ -289,6 +253,8 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
             <path
               key={`segment-${seg.segmentIndex}`}
               d={seg.pathD}
+              data-export-elevation-segment
+              data-export-elevation-color={seg.color}
               fill={`url(#segmentGradient-${seg.segmentIndex})`}
               stroke={seg.color}
               strokeWidth="1"
@@ -299,14 +265,18 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
           ))}
 
           {/* Progress overlay */}
-          {progressPathD && (
-            <path
-              d={progressPathD}
-              fill="url(#progressGradient)"
-              stroke={currentColor}
-              strokeWidth="2"
-              id="progressPath"
-            />
+          {playback.progress > 0 && (
+            <g clipPath="url(#elevationProgressClip)" data-export-elevation-dynamic>
+              {segmentPaths.map((seg) => (
+                <path
+                  key={`progress-${seg.segmentIndex}`}
+                  d={seg.pathD}
+                  fill="url(#progressGradient)"
+                  stroke={currentColor}
+                  strokeWidth="2"
+                />
+              ))}
+            </g>
           )}
 
           {/* Segment boundaries (vertical lines) */}
@@ -330,6 +300,8 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
         {/* Current elevation label - follows the progress, aligned to bottom */}
         {playback.progress > 0 && (
           <div
+            data-export-elevation-dynamic
+            data-export-elevation-label
             className={`absolute transform -translate-x-1/2 whitespace-nowrap ${
               isNonWideExportPreview
                 ? 'bottom-2'
@@ -344,6 +316,7 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
           >
             {isInTransport ? (
               <span
+                data-export-elevation-text
                 className={`block text-white ${
                   isNonWideExportPreview ? 'text-[18px] leading-none' : 'text-[12px] leading-none'
                 }`}
@@ -363,11 +336,13 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
                 }`}
               >
                 <span
+                  data-export-elevation-text
                   className={isNonWideExportPreview ? 'text-[22px] leading-none tracking-[-0.03em]' : 'text-[14px] leading-none'}
                 >
                   {formattedCurrentElev}
                 </span>
                 <span
+                  data-export-elevation-text
                   className={`font-semibold uppercase ${
                     isNonWideExportPreview ? 'text-[14px] leading-none' : 'text-[9px] leading-none'
                   }`}

--- a/app/src/components/map/MapElevationProfile.tsx
+++ b/app/src/components/map/MapElevationProfile.tsx
@@ -316,7 +316,6 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
           >
             {isInTransport ? (
               <span
-                data-export-elevation-text
                 className={`block text-white ${
                   isNonWideExportPreview ? 'text-[18px] leading-none' : 'text-[12px] leading-none'
                 }`}
@@ -336,13 +335,11 @@ export function MapElevationProfile({ className = '', exportFrame = null }: MapE
                 }`}
               >
                 <span
-                  data-export-elevation-text
                   className={isNonWideExportPreview ? 'text-[22px] leading-none tracking-[-0.03em]' : 'text-[14px] leading-none'}
                 >
                   {formattedCurrentElev}
                 </span>
                 <span
-                  data-export-elevation-text
                   className={`font-semibold uppercase ${
                     isNonWideExportPreview ? 'text-[14px] leading-none' : 'text-[9px] leading-none'
                   }`}

--- a/app/src/components/map/cameraUtils.test.ts
+++ b/app/src/components/map/cameraUtils.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest';
 import {
   calculateTerrainAwareAdjustments,
+  cameraCenterChaseDurationFromStability,
   cameraReactivityFromStability,
   frameTimeMultiplierFromDeltaMs,
   smoothBearing,
@@ -71,6 +72,32 @@ describe('camera utilities', () => {
     expect(cameraReactivityFromStability(0)).toBeCloseTo(0.25);
     expect(cameraReactivityFromStability(1)).toBeCloseTo(1.75);
     expect(cameraReactivityFromStability(Number.NaN)).toBeCloseTo(1);
+  });
+
+  it('turns the stable endpoint into a cinematic centre glide', () => {
+    expect(cameraCenterChaseDurationFromStability(0)).toBe(900);
+    expect(cameraCenterChaseDurationFromStability(0.25)).toBe(300);
+    expect(cameraCenterChaseDurationFromStability(0.5)).toBe(100);
+    expect(cameraCenterChaseDurationFromStability(1)).toBe(55);
+    expect(cameraCenterChaseDurationFromStability(Number.NaN)).toBe(100);
+  });
+
+  it('filters positional corrections much more strongly at maximum stability', () => {
+    const target: [number, number] = [10, 0];
+    const cinematic = smoothCoordinate(
+      [0, 0],
+      target,
+      1000 / 60,
+      cameraCenterChaseDurationFromStability(0),
+    );
+    const defaultCamera = smoothCoordinate(
+      [0, 0],
+      target,
+      1000 / 60,
+      cameraCenterChaseDurationFromStability(0.5),
+    );
+
+    expect(cinematic[0]).toBeLessThan(defaultCamera[0] / 5);
   });
 
   it('a low reactivity holds the heading through bigger route wiggles than the default', () => {

--- a/app/src/components/map/cameraUtils.test.ts
+++ b/app/src/components/map/cameraUtils.test.ts
@@ -8,6 +8,7 @@ import {
   smoothCoordinate,
   smoothPitch,
   smoothZoom,
+  smoothZoomTarget,
 } from './cameraUtils';
 
 describe('camera utilities', () => {
@@ -113,6 +114,25 @@ describe('camera utilities', () => {
     const stableZoom = smoothZoom(15, 16, undefined, undefined, 0.25);
     const reactiveZoom = smoothZoom(15, 16, undefined, undefined, 1.75);
     expect(reactiveZoom - 15).toBeGreaterThan(stableZoom - 15);
+  });
+
+  it('preserves terrain zoom targets at the default and reactive settings', () => {
+    expect(smoothZoomTarget(15, 13, 16, 0.5)).toBe(13);
+    expect(smoothZoomTarget(15, 13, 16, 1)).toBe(13);
+  });
+
+  it('holds small terrain zoom reversals in cinematic mode', () => {
+    expect(smoothZoomTarget(14, 14.25, 100, 0)).toBe(14);
+    expect(smoothZoomTarget(14, 13.75, 100, 0)).toBe(14);
+  });
+
+  it('opens the cinematic frame faster than it zooms back in', () => {
+    const zoomedOut = smoothZoomTarget(15, 13, 100, 0);
+    const zoomedIn = smoothZoomTarget(15, 17, 100, 0);
+
+    expect(15 - zoomedOut).toBeGreaterThan((zoomedIn - 15) * 3);
+    expect(zoomedOut).toBeGreaterThan(13);
+    expect(zoomedIn).toBeLessThan(17);
   });
 
   it('maps elapsed time to a frame-time multiplier centered on a 60fps reference frame', () => {

--- a/app/src/components/map/cameraUtils.ts
+++ b/app/src/components/map/cameraUtils.ts
@@ -11,6 +11,28 @@ export function cameraReactivityFromStability(cameraStability: number): number {
 }
 
 /**
+ * Controls how closely the camera centre chases the moving route marker.
+ *
+ * The middle of the slider preserves the original 100ms follow camera. Moving
+ * toward reactive shortens that delay a little, while the stable half ramps
+ * non-linearly into a long, floating camera move. The squared curve keeps the
+ * familiar behaviour around the default but makes the far-left endpoint a
+ * deliberate cinematic mode instead of merely a wider bearing deadband.
+ */
+export function cameraCenterChaseDurationFromStability(cameraStability: number): number {
+  const safeValue = Number.isFinite(cameraStability) ? cameraStability : 0.5;
+  const clamped = Math.max(0, Math.min(1, safeValue));
+
+  if (clamped < 0.5) {
+    const cinematicAmount = (0.5 - clamped) / 0.5;
+    return 100 + 800 * cinematicAmount * cinematicAmount;
+  }
+
+  const reactiveAmount = (clamped - 0.5) / 0.5;
+  return 100 - 45 * reactiveAmount;
+}
+
+/**
  * The smoothing constants below are per-call caps on how far the camera may
  * move. They were tuned against live playback, which updates the camera once
  * per rendered animation frame at roughly this interval. Deterministic video

--- a/app/src/components/map/cameraUtils.ts
+++ b/app/src/components/map/cameraUtils.ts
@@ -138,6 +138,42 @@ export function smoothZoom(
 }
 
 /**
+ * Low-pass filters the requested zoom before `smoothZoom` moves the camera.
+ * Terrain protection can alternate between nearby targets on rolling ground;
+ * smoothing only the camera pose still makes it reverse direction every time
+ * that target changes. Cinematic mode therefore adds target hysteresis and an
+ * asymmetric response: it opens the frame when needed, but returns to a close
+ * shot much more slowly. The default and reactive half remain unchanged.
+ */
+export function smoothZoomTarget(
+  currentTarget: number,
+  nextTarget: number,
+  deltaMs: number,
+  cameraStability: number,
+): number {
+  const safeStability = Number.isFinite(cameraStability) ? cameraStability : 0.5;
+  const clampedStability = Math.max(0, Math.min(1, safeStability));
+  const cinematicPosition = Math.max(0, (0.5 - clampedStability) / 0.5);
+  const cinematicAmount = cinematicPosition * cinematicPosition;
+
+  if (cinematicAmount === 0 || !Number.isFinite(deltaMs) || deltaMs <= 0) {
+    return nextTarget;
+  }
+
+  const difference = nextTarget - currentTarget;
+  const deadband = 0.035 + 0.265 * cinematicAmount;
+  if (Math.abs(difference) <= deadband) return currentTarget;
+
+  const openingFrame = difference < 0;
+  const responseDurationMs = openingFrame
+    ? 100 + 1_100 * cinematicAmount
+    : 100 + 4_900 * cinematicAmount;
+  const interpolation = 1 - Math.exp(-deltaMs / responseDurationMs);
+
+  return currentTarget + difference * interpolation;
+}
+
+/**
  * Keeps terrain protection from visibly tilting the horizon in steps. Reducing
  * pitch opens the view, so that safety adjustment is allowed to happen faster
  * than pitching back down into a close cinematic angle.

--- a/app/src/components/map/elevationProfile.test.ts
+++ b/app/src/components/map/elevationProfile.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest';
+import { getElevationAtProgress } from './elevationProfile';
+
+describe('elevation profile interpolation', () => {
+  const points = [
+    { progress: 0.1, elevation: 100 },
+    { progress: 0.4, elevation: 220 },
+    { progress: 0.9, elevation: 120 },
+  ];
+
+  it('interpolates smoothly between sparse GPX samples', () => {
+    expect(getElevationAtProgress(points, 0.25)).toBeCloseTo(160);
+    expect(getElevationAtProgress(points, 0.65)).toBeCloseTo(170);
+  });
+
+  it('clamps progress outside the segment', () => {
+    expect(getElevationAtProgress(points, 0)).toBe(100);
+    expect(getElevationAtProgress(points, 1)).toBe(120);
+  });
+
+  it('handles empty and repeated-progress data safely', () => {
+    expect(getElevationAtProgress([], 0.5)).toBe(0);
+    expect(getElevationAtProgress([
+      { progress: 0, elevation: 100 },
+      { progress: 0, elevation: 200 },
+      { progress: 1, elevation: 300 },
+    ], 0.5)).toBe(250);
+  });
+});

--- a/app/src/components/map/elevationProfile.ts
+++ b/app/src/components/map/elevationProfile.ts
@@ -1,0 +1,33 @@
+export interface ElevationProfileSample {
+  elevation: number;
+  progress: number;
+}
+
+/** Interpolates a sorted profile without scanning every GPX sample per frame. */
+export function getElevationAtProgress(
+  points: ElevationProfileSample[],
+  progress: number,
+): number {
+  if (points.length === 0) return 0;
+
+  const first = points[0];
+  const last = points[points.length - 1];
+  if (progress <= first.progress) return first.elevation;
+  if (progress >= last.progress) return last.elevation;
+
+  let low = 1;
+  let high = points.length - 1;
+  while (low < high) {
+    const middle = Math.floor((low + high) / 2);
+    if (points[middle].progress < progress) low = middle + 1;
+    else high = middle;
+  }
+
+  const next = points[low];
+  const previous = points[low - 1];
+  const span = next.progress - previous.progress;
+  if (span <= 0) return next.elevation;
+
+  const ratio = (progress - previous.progress) / span;
+  return previous.elevation + (next.elevation - previous.elevation) * ratio;
+}

--- a/app/src/components/map/hooks/useTrailPlaybackCamera.ts
+++ b/app/src/components/map/hooks/useTrailPlaybackCamera.ts
@@ -16,6 +16,7 @@ import {
   smoothCoordinate,
   smoothPitch,
   smoothZoom,
+  smoothZoomTarget,
 } from '@/components/map/cameraUtils';
 import { getIntroCameraPose, getPlaybackCameraPose } from '@/utils/replayCameraPlan';
 
@@ -151,6 +152,13 @@ export function useTrailPlaybackCamera({
 }: UseTrailPlaybackCameraParams) {
   const lastCameraFrameTimeRef = useRef<number | null>(null);
   const smoothedCenterRef = useRef<[number, number] | null>(null);
+  const smoothedZoomTargetRef = useRef<number | null>(null);
+
+  // Explicit distance/mode changes should take effect immediately instead of
+  // being mistaken for terrain noise by the cinematic target filter.
+  useEffect(() => {
+    smoothedZoomTargetRef.current = null;
+  }, [cameraMode, followBehindZoomLevel]);
 
   useEffect(() => {
     if (!mapRef.current || !isMapLoaded || !currentPosition) return;
@@ -350,7 +358,23 @@ export function useTrailPlaybackCamera({
       );
 
       const currentZoom = mapRef.current.getZoom();
-      const newZoom = smoothZoom(currentZoom, targetPose.zoom, undefined, undefined, reactivity, frameTimeMultiplier);
+      const stabilizedZoomTarget = smoothedZoomTargetRef.current === null || deltaMs === null
+        ? targetPose.zoom
+        : smoothZoomTarget(
+            smoothedZoomTargetRef.current,
+            targetPose.zoom,
+            deltaMs,
+            cameraStability,
+          );
+      smoothedZoomTargetRef.current = stabilizedZoomTarget;
+      const newZoom = smoothZoom(
+        currentZoom,
+        stabilizedZoomTarget,
+        undefined,
+        undefined,
+        reactivity,
+        frameTimeMultiplier,
+      );
       const newPitch = smoothPitch(mapRef.current.getPitch(), targetPose.pitch, undefined, undefined, reactivity, frameTimeMultiplier);
 
       // Chase the marker's exact position the same way live playback used to
@@ -409,6 +433,7 @@ export function useTrailPlaybackCamera({
       // since the last frame (e.g. time spent paused) be read as an elapsed
       // delta once playback resumes.
       lastCameraFrameTimeRef.current = null;
+      smoothedZoomTargetRef.current = null;
     }
 
     setCameraPosition({

--- a/app/src/components/map/hooks/useTrailPlaybackCamera.ts
+++ b/app/src/components/map/hooks/useTrailPlaybackCamera.ts
@@ -9,6 +9,7 @@ import { buildSegmentLineFeatures } from '@/utils/trailColorFeatures';
 import { buildColorZoneLineFeatures } from '@/utils/trailColorFeatures';
 import type { TrailColorZone } from '@/types';
 import {
+  cameraCenterChaseDurationFromStability,
   cameraReactivityFromStability,
   frameTimeMultiplierFromDeltaMs,
   smoothBearing,
@@ -358,9 +359,10 @@ export function useTrailPlaybackCamera({
       // can't be used directly during export). Compute it by hand here so both
       // paths land on the same rendered position.
       const targetCenter: [number, number] = [currentPosition.lon, currentPosition.lat];
+      const centerChaseDuration = cameraCenterChaseDurationFromStability(cameraStability);
       const smoothedCenter = smoothedCenterRef.current === null || deltaMs === null
         ? targetCenter
-        : smoothCoordinate(smoothedCenterRef.current, targetCenter, deltaMs);
+        : smoothCoordinate(smoothedCenterRef.current, targetCenter, deltaMs, centerChaseDuration);
       smoothedCenterRef.current = smoothedCenter;
 
       // With 3D terrain the marker is drawn on the terrain surface, while the

--- a/app/src/components/sidebar/AnnotationsPanel.tsx
+++ b/app/src/components/sidebar/AnnotationsPanel.tsx
@@ -531,24 +531,6 @@ export function AnnotationsPanel() {
             );
           })}
         </div>
-        <div className="space-y-2">
-          <div className="flex items-center justify-between">
-            <Label className="text-xs text-[var(--evergreen-60)] uppercase tracking-wide">
-              {t('annotations.statsSize')}
-            </Label>
-            <span className="text-xs text-[var(--evergreen-60)]">
-              {settings.statsScale.toFixed(1)}x
-            </span>
-          </div>
-          <Slider
-            value={[settings.statsScale]}
-            onValueChange={([value]) => setSettings({ statsScale: value })}
-            min={0.6}
-            max={2}
-            step={0.1}
-            className="w-full"
-          />
-        </div>
         {settings.visibleStats.includes('pace') && (
           <div className="space-y-1.5">
             <Label className="text-xs text-[var(--evergreen-60)] uppercase tracking-wide">

--- a/app/src/components/sidebar/AnnotationsPanel.tsx
+++ b/app/src/components/sidebar/AnnotationsPanel.tsx
@@ -531,6 +531,24 @@ export function AnnotationsPanel() {
             );
           })}
         </div>
+        <div className="space-y-2">
+          <div className="flex items-center justify-between">
+            <Label className="text-xs text-[var(--evergreen-60)] uppercase tracking-wide">
+              {t('annotations.statsSize')}
+            </Label>
+            <span className="text-xs text-[var(--evergreen-60)]">
+              {settings.statsScale.toFixed(1)}x
+            </span>
+          </div>
+          <Slider
+            value={[settings.statsScale]}
+            onValueChange={([value]) => setSettings({ statsScale: value })}
+            min={0.6}
+            max={2}
+            step={0.1}
+            className="w-full"
+          />
+        </div>
         {settings.visibleStats.includes('pace') && (
           <div className="space-y-1.5">
             <Label className="text-xs text-[var(--evergreen-60)] uppercase tracking-wide">

--- a/app/src/components/sidebar/export/exportOverlay.test.ts
+++ b/app/src/components/sidebar/export/exportOverlay.test.ts
@@ -62,6 +62,28 @@ describe('exportOverlay', () => {
     expect(rect.drawY).toBe(27);
   });
 
+  it('honors the user-selected stats scale in exported frames', () => {
+    const normal = getStatsOverlayDrawRect({
+      captureCanvas: { width: 300, height: 100 },
+      scaleToRecording: 1,
+      recordW: 1920,
+      recordH: 1080,
+      margin: 48,
+      sizeScale: 1,
+    });
+    const large = getStatsOverlayDrawRect({
+      captureCanvas: { width: 300, height: 100 },
+      scaleToRecording: 1,
+      recordW: 1920,
+      recordH: 1080,
+      margin: 48,
+      sizeScale: 1.5,
+    });
+
+    expect(large.drawWidth).toBeCloseTo(normal.drawWidth * 1.5);
+    expect(large.drawHeight).toBeCloseTo(normal.drawHeight * 1.5);
+  });
+
   it('keeps the stats overlay pinned to the top-left for landscape exports', () => {
     const rect = getStatsOverlayDrawRect({
       captureCanvas: { width: 520, height: 120 },

--- a/app/src/components/sidebar/export/exportOverlay.test.ts
+++ b/app/src/components/sidebar/export/exportOverlay.test.ts
@@ -6,6 +6,7 @@ import {
   getOverlayRefreshIntervalMs,
   getPopupOverlayDrawRect,
   getStatsOverlayDrawRect,
+  getStatsValueTimelineBucket,
   isDrawableRect,
 } from './exportOverlay';
 
@@ -15,6 +16,13 @@ describe('exportOverlay', () => {
     expect(getOverlayRefreshIntervalMs(24)).toBe(83);
     expect(getOverlayRefreshIntervalMs(12)).toBe(83);
     expect(getOverlayRefreshIntervalMs(6)).toBe(167);
+  });
+
+  it('paces native stat updates by encoded video time rather than wall-clock time', () => {
+    expect(getStatsValueTimelineBucket(0)).toBe(0);
+    expect(getStatsValueTimelineBucket(99)).toBe(0);
+    expect(getStatsValueTimelineBucket(100)).toBe(1);
+    expect(getStatsValueTimelineBucket(1_050)).toBe(10);
   });
 
   it('derives crop metrics and overlay scaling from the exported frame', () => {

--- a/app/src/components/sidebar/export/exportOverlay.ts
+++ b/app/src/components/sidebar/export/exportOverlay.ts
@@ -68,13 +68,18 @@ export function getStatsOverlayDrawRect(params: {
   containerRect?: { left: number; top: number };
   cropX?: number;
   cropY?: number;
+  /** User-selected visual scale for the complete stats block. */
+  sizeScale?: number;
 }) {
-  const rawWidth = params.captureCanvas.width * params.scaleToRecording;
+  const sizeScale = Number.isFinite(params.sizeScale)
+    ? Math.max(0.6, Math.min(2, params.sizeScale ?? 1))
+    : 1;
+  const rawWidth = params.captureCanvas.width * params.scaleToRecording * sizeScale;
   const isNarrowFrame = params.recordW <= params.recordH;
   const maxWidth = Math.min(
     rawWidth,
     params.recordW - (params.margin * 2),
-    params.recordW * (isNarrowFrame ? 0.56 : 0.28),
+    params.recordW * (isNarrowFrame ? 0.56 : 0.28) * Math.max(1, sizeScale),
   );
   const drawWidth = Math.max(0, maxWidth);
   const drawHeight = params.captureCanvas.height * (drawWidth / params.captureCanvas.width);

--- a/app/src/components/sidebar/export/exportOverlay.ts
+++ b/app/src/components/sidebar/export/exportOverlay.ts
@@ -21,6 +21,11 @@ export function getOverlayRefreshIntervalMs(fps: number) {
   return Math.max(83, Math.round(1000 / Math.min(fps, 12)));
 }
 
+export function getStatsValueTimelineBucket(currentTimeMs: number) {
+  const safeTime = Number.isFinite(currentTimeMs) ? Math.max(0, currentTimeMs) : 0;
+  return Math.floor(safeTime / 100);
+}
+
 export function getExportOverlayMetrics(
   containerRect: Size,
   recordW: number,

--- a/app/src/components/sidebar/export/useExportOverlayCapture.ts
+++ b/app/src/components/sidebar/export/useExportOverlayCapture.ts
@@ -1,5 +1,8 @@
-import { useCallback, useRef } from 'react';
+import { useCallback, useMemo, useRef } from 'react';
 import { useAppStore } from '@/store/useAppStore';
+import { getElevationAtProgress } from '@/components/map/elevationProfile';
+import { TRANSPORT_ICONS } from '@/utils/journeyUtils';
+import { convertElevation } from '@/utils/units';
 import {
   getCapturedCanvasDrawSize,
   getElevationOverlayDrawRect,
@@ -29,11 +32,18 @@ declare global {
 }
 
 interface UseExportOverlayCaptureOptions {
+  elevationData: Array<{
+    elevation: number;
+    progress: number;
+    segmentIndex: number;
+    segmentType: 'track' | 'transport';
+  }>;
   includeElevation: boolean;
   includeStats: boolean;
 }
 
 export function useExportOverlayCapture({
+  elevationData,
   includeElevation,
   includeStats,
 }: UseExportOverlayCaptureOptions) {
@@ -43,6 +53,23 @@ export function useExportOverlayCapture({
   const html2CanvasLoaderRef = useRef<Promise<boolean> | null>(null);
   const overlayRunIdRef = useRef(0);
   const elevationPathCacheRef = useRef(new Map<string, Path2D>());
+  const elevationSegments = useMemo(() => {
+    const segments = new Map<number, {
+      points: Array<{ elevation: number; progress: number }>;
+      type: 'track' | 'transport';
+    }>();
+
+    elevationData.forEach((sample) => {
+      const segment = segments.get(sample.segmentIndex) ?? {
+        points: [],
+        type: sample.segmentType,
+      };
+      segment.points.push({ elevation: sample.elevation, progress: sample.progress });
+      segments.set(sample.segmentIndex, segment);
+    });
+    segments.forEach((segment) => segment.points.sort((a, b) => a.progress - b.progress));
+    return segments;
+  }, [elevationData]);
 
   const loadHtml2Canvas = useCallback(async (): Promise<boolean> => {
     if (window.html2canvas) return true;
@@ -245,31 +272,69 @@ export function useExportOverlayCapture({
     });
     context.restore();
 
-    const label = document.querySelector('[data-export-elevation-label]');
-    label?.querySelectorAll<HTMLElement>('[data-export-elevation-text]').forEach((textElement) => {
-      const text = textElement.textContent?.trim();
-      if (!text) return;
+    if (progress <= 0) return;
 
-      const rect = textElement.getBoundingClientRect();
-      const style = getComputedStyle(textElement);
-      const centerX = overlayRect.drawX
-        + (rect.left + rect.width / 2 - elementRect.left) * elementScaleX;
-      const centerY = overlayRect.drawY
-        + (rect.top + rect.height / 2 - elementRect.top) * elementScaleY;
-      const fontSize = (Number.parseFloat(style.fontSize) || 12) * elementScaleY;
-
-      context.save();
-      context.font = `${style.fontWeight || '700'} ${fontSize}px ${style.fontFamily || 'sans-serif'}`;
-      context.textAlign = 'center';
-      context.textBaseline = 'middle';
-      context.fillStyle = style.color || '#ffffff';
-      context.shadowColor = 'rgba(0, 0, 0, 0.8)';
-      context.shadowBlur = 5 * elementScaleY;
-      context.shadowOffsetY = 2 * elementScaleY;
-      context.fillText(text, centerX, centerY);
-      context.restore();
+    let currentSegment: {
+      points: Array<{ elevation: number; progress: number }>;
+      type: 'track' | 'transport';
+    } | undefined;
+    let currentSegmentIndex = 0;
+    elevationSegments.forEach((segment, segmentIndex) => {
+      const first = segment.points[0];
+      const last = segment.points[segment.points.length - 1];
+      if (first && last && progress >= first.progress && progress <= last.progress) {
+        currentSegment = segment;
+        currentSegmentIndex = segmentIndex;
+      }
     });
-  }, [includeElevation]);
+    if (!currentSegment) return;
+
+    const state = useAppStore.getState();
+    const unitSystem = state.settings.unitSystem;
+    const isCompact = recordW > recordH;
+    const centerX = drawX + progress * drawWidth;
+    const baselineY = overlayRect.drawY
+      + overlayRect.drawHeight
+      - (isCompact ? 4 : 8) * elementScaleY;
+
+    context.save();
+    context.textBaseline = 'bottom';
+    context.fillStyle = '#ffffff';
+    context.shadowColor = 'rgba(0, 0, 0, 0.8)';
+    context.shadowBlur = 5 * elementScaleY;
+    context.shadowOffsetY = 2 * elementScaleY;
+
+    if (currentSegment.type === 'transport') {
+      const journeySegment = state.journeySegments[currentSegmentIndex];
+      const mode = journeySegment?.type === 'transport' ? journeySegment.mode : 'car';
+      const icon = TRANSPORT_ICONS[mode] || '🚗';
+      context.font = `${(isCompact ? 12 : 18) * elementScaleY}px sans-serif`;
+      context.textAlign = 'center';
+      context.fillText(icon, centerX, baselineY);
+    } else {
+      const elevation = getElevationAtProgress(currentSegment.points, progress);
+      const value = String(Math.round(convertElevation(elevation, unitSystem)));
+      const unit = unitSystem === 'metric' ? 'M' : 'FT';
+      const valueSize = (isCompact ? 14 : 22) * elementScaleY;
+      const unitSize = (isCompact ? 9 : 14) * elementScaleY;
+      const gap = (isCompact ? 4 : 6) * elementScaleX;
+      const family = 'JetBrains Mono, monospace';
+
+      context.font = `700 ${valueSize}px ${family}`;
+      const valueWidth = context.measureText(value).width;
+      context.font = `600 ${unitSize}px ${family}`;
+      const unitWidth = context.measureText(unit).width;
+      let textX = centerX - (valueWidth + gap + unitWidth) / 2;
+
+      context.textAlign = 'left';
+      context.font = `700 ${valueSize}px ${family}`;
+      context.fillText(value, textX, baselineY);
+      textX += valueWidth + gap;
+      context.font = `600 ${unitSize}px ${family}`;
+      context.fillText(unit, textX, baselineY);
+    }
+    context.restore();
+  }, [elevationSegments, includeElevation]);
 
   const resetOverlayCapture = useCallback(() => {
     cachedOverlayRef.current = null;

--- a/app/src/components/sidebar/export/useExportOverlayCapture.ts
+++ b/app/src/components/sidebar/export/useExportOverlayCapture.ts
@@ -24,6 +24,9 @@ type Html2Canvas = (
     useCORS: boolean;
     allowTaint?: boolean;
     ignoreElements?: (element: Element) => boolean;
+    onclone?: (documentClone: Document) => void;
+    width?: number;
+    height?: number;
   }
 ) => Promise<HTMLCanvasElement>;
 
@@ -134,12 +137,24 @@ export function useExportOverlayCapture({
               logging: false,
               useCORS: true,
               allowTaint: true,
+              width: statsElement.offsetWidth,
+              height: statsElement.offsetHeight,
               ignoreElements: (element) => element.hasAttribute('data-export-stat-value'),
+              // Capture the intrinsic 1x overlay, then apply statsScale once
+              // in the export layout math below. Otherwise html2canvas may
+              // bake the preview's ancestor transform into the bitmap and the
+              // compositor would scale it a second time.
+              onclone: (documentClone) => {
+                const scaleWrapper = documentClone.querySelector('[data-stats-scale-wrapper]') as HTMLElement | null;
+                if (scaleWrapper) scaleWrapper.style.transform = 'none';
+              },
             });
             const { drawWidth, drawHeight } = getCapturedCanvasDrawSize(captureCanvas, scaleToRecording, statsCaptureScale);
             const hasCustomPosition = useAppStore.getState().settings.statsPosition !== null;
+            const statsScale = useAppStore.getState().settings.statsScale ?? 1;
             const statsDrawRect = getStatsOverlayDrawRect({
               captureCanvas: { width: drawWidth, height: drawHeight }, scaleToRecording: 1, positionScale: scaleToRecording, recordW, recordH, margin,
+              sizeScale: statsScale,
               ...(hasCustomPosition && { elementRect: statsRect, containerRect, cropX, cropY }),
             });
             overlayContext.drawImage(captureCanvas, 0, 0, captureCanvas.width, captureCanvas.height, statsDrawRect.drawX, statsDrawRect.drawY, statsDrawRect.drawWidth, statsDrawRect.drawHeight);
@@ -254,16 +269,18 @@ export function useExportOverlayCapture({
 
     const margin = Math.round(recordW * 0.025);
     const hasCustomPosition = state.settings.statsPosition !== null;
+    const statsScale = state.settings.statsScale ?? 1;
     const drawRect = getStatsOverlayDrawRect({
       captureCanvas: {
-        width: statsRect.width * scaleToRecording,
-        height: statsRect.height * scaleToRecording,
+        width: (statsRect.width / statsScale) * scaleToRecording,
+        height: (statsRect.height / statsScale) * scaleToRecording,
       },
       scaleToRecording: 1,
       positionScale: scaleToRecording,
       recordW,
       recordH,
       margin,
+      sizeScale: statsScale,
       ...(hasCustomPosition && { elementRect: statsRect, containerRect, cropX, cropY }),
     });
     const elementScaleX = drawRect.drawWidth / statsRect.width;

--- a/app/src/components/sidebar/export/useExportOverlayCapture.ts
+++ b/app/src/components/sidebar/export/useExportOverlayCapture.ts
@@ -42,6 +42,7 @@ export function useExportOverlayCapture({
   const overlayLastUpdateRef = useRef(0);
   const html2CanvasLoaderRef = useRef<Promise<boolean> | null>(null);
   const overlayRunIdRef = useRef(0);
+  const elevationPathCacheRef = useRef(new Map<string, Path2D>());
 
   const loadHtml2Canvas = useCallback(async (): Promise<boolean> => {
     if (window.html2canvas) return true;
@@ -108,7 +109,16 @@ export function useExportOverlayCapture({
         const elevationElement = document.getElementById('mapElevationProfile') as HTMLElement | null;
         if (elevationElement) {
           try {
-            const captureCanvas = await capture(elevationElement, { backgroundColor: null, scale: 1, logging: false, useCORS: true });
+            const captureCanvas = await capture(elevationElement, {
+              backgroundColor: null,
+              scale: 1,
+              logging: false,
+              useCORS: true,
+              // The progress fill and elevation label are drawn directly onto
+              // every video frame below. Keeping them out of this comparatively
+              // expensive DOM snapshot prevents a stale 12fps copy underneath.
+              ignoreElements: (element) => element.hasAttribute('data-export-elevation-dynamic'),
+            });
             const rect = getElevationOverlayDrawRect({ captureCanvas, scaleToRecording, recordW, recordH, margin });
             overlayContext.drawImage(captureCanvas, 0, 0, captureCanvas.width, captureCanvas.height, rect.drawX, rect.drawY, rect.drawWidth, rect.drawHeight);
           } catch { /* Skip overlay when capture fails. */ }
@@ -162,12 +172,120 @@ export function useExportOverlayCapture({
     }
   }, [includeElevation, includeStats]);
 
+  const drawElevationProgress = useCallback((
+    context: CanvasRenderingContext2D,
+    {
+      recordW,
+      recordH,
+      scaleToRecording,
+    }: {
+      recordW: number;
+      recordH: number;
+      scaleToRecording: number;
+    },
+  ) => {
+    if (!includeElevation || typeof Path2D === 'undefined') return;
+
+    const svg = document.getElementById('elevationProfileSvg') as SVGSVGElement | null;
+    const elevationElement = document.getElementById('mapElevationProfile');
+    if (!svg || !elevationElement) return;
+
+    const viewBox = svg.viewBox.baseVal;
+    if (viewBox.width <= 0 || viewBox.height <= 0) return;
+
+    const elementRect = elevationElement.getBoundingClientRect();
+    const svgRect = svg.getBoundingClientRect();
+    if (elementRect.width <= 0 || elementRect.height <= 0) return;
+
+    // Match the exact centered/constrained rect used for the cached static
+    // elevation snapshot, then place the SVG and label within that rect using
+    // their DOM-relative positions.
+    const overlayRect = getElevationOverlayDrawRect({
+      captureCanvas: { width: elementRect.width, height: elementRect.height },
+      scaleToRecording,
+      recordW,
+      recordH,
+      margin: Math.round(recordW * 0.025),
+    });
+    const elementScaleX = overlayRect.drawWidth / elementRect.width;
+    const elementScaleY = overlayRect.drawHeight / elementRect.height;
+    const drawX = overlayRect.drawX + (svgRect.left - elementRect.left) * elementScaleX;
+    const drawY = overlayRect.drawY + (svgRect.top - elementRect.top) * elementScaleY;
+    const drawWidth = svgRect.width * elementScaleX;
+    const drawHeight = svgRect.height * elementScaleY;
+    const progress = Math.max(0, Math.min(1, useAppStore.getState().playback.progress));
+
+    context.save();
+    context.translate(drawX, drawY);
+    context.scale(drawWidth / viewBox.width, drawHeight / viewBox.height);
+    context.beginPath();
+    context.rect(viewBox.x, viewBox.y, viewBox.width * progress, viewBox.height);
+    context.clip();
+
+    svg.querySelectorAll<SVGPathElement>('[data-export-elevation-segment]').forEach((element) => {
+      const pathData = element.getAttribute('d');
+      if (!pathData) return;
+
+      let path = elevationPathCacheRef.current.get(pathData);
+      if (!path) {
+        path = new Path2D(pathData);
+        elevationPathCacheRef.current.set(pathData, path);
+      }
+
+      const color = svg.dataset.exportElevationProgressColor
+        || element.dataset.exportElevationColor
+        || '#c1652f';
+      context.globalAlpha = 0.7;
+      context.fillStyle = color;
+      context.fill(path);
+      context.globalAlpha = 1;
+      context.strokeStyle = color;
+      context.lineWidth = 2;
+      context.stroke(path);
+    });
+    context.restore();
+
+    const label = document.querySelector('[data-export-elevation-label]');
+    label?.querySelectorAll<HTMLElement>('[data-export-elevation-text]').forEach((textElement) => {
+      const text = textElement.textContent?.trim();
+      if (!text) return;
+
+      const rect = textElement.getBoundingClientRect();
+      const style = getComputedStyle(textElement);
+      const centerX = overlayRect.drawX
+        + (rect.left + rect.width / 2 - elementRect.left) * elementScaleX;
+      const centerY = overlayRect.drawY
+        + (rect.top + rect.height / 2 - elementRect.top) * elementScaleY;
+      const fontSize = (Number.parseFloat(style.fontSize) || 12) * elementScaleY;
+
+      context.save();
+      context.font = `${style.fontWeight || '700'} ${fontSize}px ${style.fontFamily || 'sans-serif'}`;
+      context.textAlign = 'center';
+      context.textBaseline = 'middle';
+      context.fillStyle = style.color || '#ffffff';
+      context.shadowColor = 'rgba(0, 0, 0, 0.8)';
+      context.shadowBlur = 5 * elementScaleY;
+      context.shadowOffsetY = 2 * elementScaleY;
+      context.fillText(text, centerX, centerY);
+      context.restore();
+    });
+  }, [includeElevation]);
+
   const resetOverlayCapture = useCallback(() => {
     cachedOverlayRef.current = null;
     overlayBusyRef.current = false;
     overlayLastUpdateRef.current = 0;
     overlayRunIdRef.current += 1;
+    elevationPathCacheRef.current.clear();
   }, []);
 
-  return { cachedOverlayRef, loadHtml2Canvas, overlayBusyRef, overlayLastUpdateRef, resetOverlayCapture, updateOverlayAsync };
+  return {
+    cachedOverlayRef,
+    drawElevationProgress,
+    loadHtml2Canvas,
+    overlayBusyRef,
+    overlayLastUpdateRef,
+    resetOverlayCapture,
+    updateOverlayAsync,
+  };
 }

--- a/app/src/components/sidebar/export/useExportOverlayCapture.ts
+++ b/app/src/components/sidebar/export/useExportOverlayCapture.ts
@@ -3,6 +3,7 @@ import { useAppStore } from '@/store/useAppStore';
 import { getElevationAtProgress } from '@/components/map/elevationProfile';
 import { TRANSPORT_ICONS } from '@/utils/journeyUtils';
 import { convertElevation } from '@/utils/units';
+import type { StatId } from '@/types';
 import {
   getCapturedCanvasDrawSize,
   getElevationOverlayDrawRect,
@@ -10,6 +11,7 @@ import {
   getObjectContainRect,
   getPopupOverlayDrawRect,
   getStatsOverlayDrawRect,
+  getStatsValueTimelineBucket,
   isDrawableRect,
 } from './exportOverlay';
 
@@ -40,10 +42,12 @@ interface UseExportOverlayCaptureOptions {
   }>;
   includeElevation: boolean;
   includeStats: boolean;
+  getStatsValues: (progress: number) => Partial<Record<StatId, string>>;
 }
 
 export function useExportOverlayCapture({
   elevationData,
+  getStatsValues,
   includeElevation,
   includeStats,
 }: UseExportOverlayCaptureOptions) {
@@ -53,6 +57,10 @@ export function useExportOverlayCapture({
   const html2CanvasLoaderRef = useRef<Promise<boolean> | null>(null);
   const overlayRunIdRef = useRef(0);
   const elevationPathCacheRef = useRef(new Map<string, Path2D>());
+  const statsValuesCacheRef = useRef<{
+    timelineBucket: number;
+    values: Partial<Record<StatId, string>>;
+  }>({ timelineBucket: -1, values: {} });
   const elevationSegments = useMemo(() => {
     const segments = new Map<number, {
       points: Array<{ elevation: number; progress: number }>;
@@ -120,7 +128,14 @@ export function useExportOverlayCapture({
           try {
             const statsCaptureScale = 4;
             const statsRect = statsElement.getBoundingClientRect();
-            const captureCanvas = await capture(statsElement, { backgroundColor: null, scale: statsCaptureScale, logging: false, useCORS: true, allowTaint: true });
+            const captureCanvas = await capture(statsElement, {
+              backgroundColor: null,
+              scale: statsCaptureScale,
+              logging: false,
+              useCORS: true,
+              allowTaint: true,
+              ignoreElements: (element) => element.hasAttribute('data-export-stat-value'),
+            });
             const { drawWidth, drawHeight } = getCapturedCanvasDrawSize(captureCanvas, scaleToRecording, statsCaptureScale);
             const hasCustomPosition = useAppStore.getState().settings.statsPosition !== null;
             const statsDrawRect = getStatsOverlayDrawRect({
@@ -198,6 +213,84 @@ export function useExportOverlayCapture({
       overlayBusyRef.current = false;
     }
   }, [includeElevation, includeStats]);
+
+  const drawStatsValues = useCallback((
+    context: CanvasRenderingContext2D,
+    {
+      containerRect,
+      cropX,
+      cropY,
+      recordW,
+      recordH,
+      scaleToRecording,
+    }: {
+      containerRect: DOMRect;
+      cropX: number;
+      cropY: number;
+      recordW: number;
+      recordH: number;
+      scaleToRecording: number;
+    },
+  ) => {
+    if (!includeStats) return;
+
+    const statsElement = document.querySelector('.tr-stats-overlay') as HTMLElement | null;
+    if (!statsElement) return;
+
+    const state = useAppStore.getState();
+    // Ten value updates per second of encoded video are visually fluid for
+    // changing numerals, while avoiding repeated route-stat calculations on
+    // every 30/60fps frame. Drawing the cached values remains per-frame.
+    const timelineBucket = getStatsValueTimelineBucket(state.playback.currentTime);
+    if (timelineBucket !== statsValuesCacheRef.current.timelineBucket) {
+      statsValuesCacheRef.current = {
+        timelineBucket,
+        values: getStatsValues(state.playback.progress),
+      };
+    }
+
+    const statsRect = statsElement.getBoundingClientRect();
+    if (statsRect.width <= 0 || statsRect.height <= 0) return;
+
+    const margin = Math.round(recordW * 0.025);
+    const hasCustomPosition = state.settings.statsPosition !== null;
+    const drawRect = getStatsOverlayDrawRect({
+      captureCanvas: {
+        width: statsRect.width * scaleToRecording,
+        height: statsRect.height * scaleToRecording,
+      },
+      scaleToRecording: 1,
+      positionScale: scaleToRecording,
+      recordW,
+      recordH,
+      margin,
+      ...(hasCustomPosition && { elementRect: statsRect, containerRect, cropX, cropY }),
+    });
+    const elementScaleX = drawRect.drawWidth / statsRect.width;
+    const elementScaleY = drawRect.drawHeight / statsRect.height;
+
+    statsElement.querySelectorAll<HTMLElement>('[data-export-stat-value]').forEach((valueElement) => {
+      const id = valueElement.dataset.exportStatValue as StatId | undefined;
+      const value = id ? statsValuesCacheRef.current.values[id] : undefined;
+      if (!value) return;
+
+      const rect = valueElement.getBoundingClientRect();
+      const style = getComputedStyle(valueElement);
+      const centerX = drawRect.drawX
+        + (rect.left + rect.width / 2 - statsRect.left) * elementScaleX;
+      const centerY = drawRect.drawY
+        + (rect.top + rect.height / 2 - statsRect.top) * elementScaleY;
+      const fontSize = (Number.parseFloat(style.fontSize) || 9) * elementScaleY;
+
+      context.save();
+      context.font = `${style.fontWeight || '600'} ${fontSize}px ${style.fontFamily || 'sans-serif'}`;
+      context.textAlign = 'center';
+      context.textBaseline = 'middle';
+      context.fillStyle = style.color || '#ffffff';
+      context.fillText(value, centerX, centerY);
+      context.restore();
+    });
+  }, [getStatsValues, includeStats]);
 
   const drawElevationProgress = useCallback((
     context: CanvasRenderingContext2D,
@@ -342,11 +435,13 @@ export function useExportOverlayCapture({
     overlayLastUpdateRef.current = 0;
     overlayRunIdRef.current += 1;
     elevationPathCacheRef.current.clear();
+    statsValuesCacheRef.current = { timelineBucket: -1, values: {} };
   }, []);
 
   return {
     cachedOverlayRef,
     drawElevationProgress,
+    drawStatsValues,
     loadHtml2Canvas,
     overlayBusyRef,
     overlayLastUpdateRef,

--- a/app/src/components/sidebar/export/useVideoExportRecorder.ts
+++ b/app/src/components/sidebar/export/useVideoExportRecorder.ts
@@ -125,6 +125,7 @@ export function useVideoExportRecorder() {
     resetOverlayCapture,
     updateOverlayAsync,
   } = useExportOverlayCapture({
+    elevationData,
     includeElevation,
     includeStats,
   });

--- a/app/src/components/sidebar/export/useVideoExportRecorder.ts
+++ b/app/src/components/sidebar/export/useVideoExportRecorder.ts
@@ -118,6 +118,7 @@ export function useVideoExportRecorder() {
   const overlayRefreshIntervalMs = useMemo(() => getOverlayRefreshIntervalMs(videoExportSettings.fps), [videoExportSettings.fps]);
   const {
     cachedOverlayRef,
+    drawElevationProgress,
     loadHtml2Canvas,
     overlayBusyRef,
     overlayLastUpdateRef,
@@ -212,6 +213,16 @@ export function useVideoExportRecorder() {
 
     const scaleX = recordW / cropW;
     const scaleY = recordH / cropH;
+
+    // The static elevation profile remains in the cached DOM snapshot, while
+    // its progress fill and label are cheap native-canvas primitives. Drawing
+    // only those moving pieces here keeps them at the actual video frame rate
+    // without running html2canvas 30 or 60 times per second.
+    drawElevationProgress(context, {
+      recordW,
+      recordH,
+      scaleToRecording: scaleX,
+    });
 
     // The photo popup should read as fully in front of everything else
     // (matching the live view's z-index stacking): neither the route
@@ -325,7 +336,7 @@ export function useVideoExportRecorder() {
     if (Date.now() - overlayLastUpdateRef.current >= overlayRefreshIntervalMs && !overlayBusyRef.current) {
       updateOverlayAsync(recordW, recordH);
     }
-  }, [cachedOverlayRef, overlayBusyRef, overlayLastUpdateRef, overlayRefreshIntervalMs, preloadSvgMarkerIcon, updateOverlayAsync, videoExportSettings.resolution]);
+  }, [cachedOverlayRef, drawElevationProgress, overlayBusyRef, overlayLastUpdateRef, overlayRefreshIntervalMs, preloadSvgMarkerIcon, updateOverlayAsync, videoExportSettings.resolution]);
 
   // When encoding via WebCodecs, push the freshly drawn canvas to the encoder.
   // No-op for the MediaRecorder path, which samples the canvas stream itself.

--- a/app/src/components/sidebar/export/useVideoExportRecorder.ts
+++ b/app/src/components/sidebar/export/useVideoExportRecorder.ts
@@ -14,6 +14,22 @@ import {
 } from '@/utils/analytics';
 import { getActivityIconOption, isSvgActivityIcon } from '@/utils/activityIcons';
 import { getTriggeredPlaybackPictures } from '@/utils/playbackPictures';
+import { interpolateTrackPoint } from '@/utils/gpx/interpolateTrackPoint';
+import {
+  buildJourneyDistanceProfile,
+  getJourneyPointAtDistance,
+  getJourneyPointAtProgress,
+  type JourneyPoint,
+} from '@/utils/journeyUtils';
+import {
+  formatDistance,
+  formatElevation,
+  formatPace,
+  formatSpeedFromKmh,
+  formatStatsDuration,
+} from '@/utils/units';
+import { calculateCurrentLiveStats } from '@/components/stats/liveStats';
+import type { StatId } from '@/types';
 import {
   getSupportedMimeType,
   getVideoBitrate,
@@ -101,7 +117,18 @@ export function useVideoExportRecorder() {
   const setSpeed = useAppStore((state) => state.setSpeed);
   const play = useAppStore((state) => state.play);
   const setCinematicPlayed = useAppStore((state) => state.setCinematicPlayed);
-  const { cameraPathCoordinates, elevationData } = useComputedJourney();
+  const {
+    activeTrack,
+    cameraPathCoordinates,
+    computedJourney,
+    elevationData,
+    segmentTimings,
+    totalDistance,
+  } = useComputedJourney();
+  const journeyDistanceProfile = useMemo(
+    () => computedJourney ? buildJourneyDistanceProfile(computedJourney.coordinates) : null,
+    [computedJourney],
+  );
 
   const [exportedBlob, setExportedBlob] = useState<Blob | null>(null);
 
@@ -116,9 +143,88 @@ export function useVideoExportRecorder() {
   const includeStats = visibleStats.length > 0;
   const includeElevation = showElevationProfile;
   const overlayRefreshIntervalMs = useMemo(() => getOverlayRefreshIntervalMs(videoExportSettings.fps), [videoExportSettings.fps]);
+  const getStatsValues = useCallback((progress: number): Partial<Record<StatId, string>> => {
+    const state = useAppStore.getState();
+    const routeTimingMode = state.playback.routeTimingMode;
+    let journeyPosition: JourneyPoint | null = null;
+    if (computedJourney) {
+      journeyPosition = routeTimingMode === 'uniform' && journeyDistanceProfile
+        ? getJourneyPointAtDistance(
+            journeyDistanceProfile,
+            journeyDistanceProfile.totalDistance * progress,
+          )
+        : getJourneyPointAtProgress(progress, computedJourney.coordinates, segmentTimings);
+    } else if (activeTrack) {
+      const trackPosition = interpolateTrackPoint(activeTrack, activeTrack.totalDistance * progress);
+      if (trackPosition) {
+        journeyPosition = {
+          ...trackPosition,
+          segmentIndex: 0,
+          segmentType: 'track',
+          trackId: activeTrack.id,
+        };
+      }
+    }
+    if (!journeyPosition) return {};
+    const currentStats = calculateCurrentLiveStats({
+      activeTrack,
+      computedJourney,
+      currentPosition: journeyPosition,
+      playbackProgress: progress,
+      restartPerTrack: state.settings.journeyStatsMode === 'per-track',
+      segmentTimings,
+      totalDistance,
+      tracks: state.tracks,
+      videoDurationSeconds: state.playback.totalDuration / 1000,
+    });
+    const isInTransport = journeyPosition.segmentType === 'transport';
+    const values: Partial<Record<StatId, string>> = {};
+
+    state.settings.visibleStats.forEach((id) => {
+      switch (id) {
+        case 'duration':
+          values[id] = formatStatsDuration(currentStats.duration);
+          break;
+        case 'distance':
+          values[id] = formatDistance(currentStats.distance, state.settings.unitSystem);
+          break;
+        case 'pace':
+          values[id] = isInTransport
+            ? '--'
+            : formatPace(
+                state.settings.paceMode === 'per-km'
+                  ? currentStats.rollingSpeed
+                  : currentStats.averageSpeed,
+                state.settings.unitSystem,
+              );
+          break;
+        case 'elevation':
+          values[id] = isInTransport
+            ? '--'
+            : formatElevation(currentStats.elevationGain, state.settings.unitSystem);
+          break;
+        case 'speed':
+          values[id] = formatSpeedFromKmh(currentStats.currentSpeed, state.settings.unitSystem);
+          break;
+        case 'altitude':
+          values[id] = currentStats.altitude !== null
+            ? formatElevation(currentStats.altitude, state.settings.unitSystem)
+            : '--';
+          break;
+        case 'heartRate':
+          if (currentStats.heartRate) {
+            values[id] = `${Math.round(currentStats.heartRate)} ${t('stats.bpm')}`;
+          }
+          break;
+      }
+    });
+
+    return values;
+  }, [activeTrack, computedJourney, journeyDistanceProfile, segmentTimings, t, totalDistance]);
   const {
     cachedOverlayRef,
     drawElevationProgress,
+    drawStatsValues,
     loadHtml2Canvas,
     overlayBusyRef,
     overlayLastUpdateRef,
@@ -126,6 +232,7 @@ export function useVideoExportRecorder() {
     updateOverlayAsync,
   } = useExportOverlayCapture({
     elevationData,
+    getStatsValues,
     includeElevation,
     includeStats,
   });
@@ -219,6 +326,14 @@ export function useVideoExportRecorder() {
     // its progress fill and label are cheap native-canvas primitives. Drawing
     // only those moving pieces here keeps them at the actual video frame rate
     // without running html2canvas 30 or 60 times per second.
+    drawStatsValues(context, {
+      containerRect,
+      cropX,
+      cropY,
+      recordW,
+      recordH,
+      scaleToRecording: scaleX,
+    });
     drawElevationProgress(context, {
       recordW,
       recordH,
@@ -337,7 +452,7 @@ export function useVideoExportRecorder() {
     if (Date.now() - overlayLastUpdateRef.current >= overlayRefreshIntervalMs && !overlayBusyRef.current) {
       updateOverlayAsync(recordW, recordH);
     }
-  }, [cachedOverlayRef, drawElevationProgress, overlayBusyRef, overlayLastUpdateRef, overlayRefreshIntervalMs, preloadSvgMarkerIcon, updateOverlayAsync, videoExportSettings.resolution]);
+  }, [cachedOverlayRef, drawElevationProgress, drawStatsValues, overlayBusyRef, overlayLastUpdateRef, overlayRefreshIntervalMs, preloadSvgMarkerIcon, updateOverlayAsync, videoExportSettings.resolution]);
 
   // When encoding via WebCodecs, push the freshly drawn canvas to the encoder.
   // No-op for the MediaRecorder path, which samples the canvas stream itself.

--- a/app/src/components/sidebar/export/useVideoExportRecorder.ts
+++ b/app/src/components/sidebar/export/useVideoExportRecorder.ts
@@ -17,6 +17,8 @@ import { getTriggeredPlaybackPictures } from '@/utils/playbackPictures';
 import { interpolateTrackPoint } from '@/utils/gpx/interpolateTrackPoint';
 import {
   buildJourneyDistanceProfile,
+  getSegmentAtDistance,
+  getSegmentAtProgress,
   getJourneyPointAtDistance,
   getJourneyPointAtProgress,
   type JourneyPoint,
@@ -221,6 +223,31 @@ export function useVideoExportRecorder() {
 
     return values;
   }, [activeTrack, computedJourney, journeyDistanceProfile, segmentTimings, t, totalDistance]);
+  const getTrackLabel = useCallback((progress: number): { color: string; text: string } | null => {
+    const state = useAppStore.getState();
+    if (!state.settings.trailStyle.showTrackLabels) return null;
+
+    if (!computedJourney) {
+      return activeTrack
+        ? { color: state.settings.trailStyle.trailColor, text: activeTrack.name }
+        : null;
+    }
+
+    const currentSegment = state.playback.routeTimingMode === 'uniform' && journeyDistanceProfile
+      ? getSegmentAtDistance(
+          journeyDistanceProfile,
+          journeyDistanceProfile.totalDistance * progress,
+          segmentTimings,
+        )
+      : getSegmentAtProgress(progress, segmentTimings);
+    const trackId = currentSegment?.segment.type === 'track'
+      ? currentSegment.segment.trackId
+      : undefined;
+    const track = trackId ? state.tracks.find((candidate) => candidate.id === trackId) : null;
+    return track
+      ? { color: track.color || state.settings.trailStyle.trailColor, text: track.name }
+      : null;
+  }, [activeTrack, computedJourney, journeyDistanceProfile, segmentTimings]);
   const {
     cachedOverlayRef,
     drawElevationProgress,
@@ -430,6 +457,24 @@ export function useVideoExportRecorder() {
           context.fillText(markerIcon.textContent, markerX, markerY);
         }
       }
+
+      const trackLabel = getTrackLabel(useAppStore.getState().playback.progress);
+      if (trackLabel?.text) {
+        const labelFontSize = 12 * scaleY;
+        const markerTop = markerY - (markerRect.height / 2) * scaleY;
+
+        context.save();
+        context.font = `700 ${labelFontSize}px JetBrains Mono, monospace`;
+        context.textAlign = 'center';
+        context.textBaseline = 'bottom';
+        context.lineJoin = 'round';
+        context.strokeStyle = '#ffffff';
+        context.lineWidth = 3 * scaleY;
+        context.strokeText(trackLabel.text, markerX, markerTop - 8 * scaleY);
+        context.fillStyle = trackLabel.color;
+        context.fillText(trackLabel.text, markerX, markerTop - 8 * scaleY);
+        context.restore();
+      }
     }
 
     if (cachedLogoRef.current) {
@@ -452,7 +497,7 @@ export function useVideoExportRecorder() {
     if (Date.now() - overlayLastUpdateRef.current >= overlayRefreshIntervalMs && !overlayBusyRef.current) {
       updateOverlayAsync(recordW, recordH);
     }
-  }, [cachedOverlayRef, drawElevationProgress, drawStatsValues, overlayBusyRef, overlayLastUpdateRef, overlayRefreshIntervalMs, preloadSvgMarkerIcon, updateOverlayAsync, videoExportSettings.resolution]);
+  }, [cachedOverlayRef, drawElevationProgress, drawStatsValues, getTrackLabel, overlayBusyRef, overlayLastUpdateRef, overlayRefreshIntervalMs, preloadSvgMarkerIcon, updateOverlayAsync, videoExportSettings.resolution]);
 
   // When encoding via WebCodecs, push the freshly drawn canvas to the encoder.
   // No-op for the MediaRecorder path, which samples the canvas stream itself.

--- a/app/src/components/stats/StatsOverlay.tsx
+++ b/app/src/components/stats/StatsOverlay.tsx
@@ -152,13 +152,16 @@ export function StatsOverlay({ compact = false, layout = 'default', variant = 'd
 
   if (visibleStats.length === 0) return null;
 
-  const cols = isVerticalLayout
+  const configuredColumns = Number.isFinite(settings.statsColumns)
+    ? Math.max(1, Math.min(visibleStats.length, Math.round(settings.statsColumns ?? 1)))
+    : null;
+  const cols = configuredColumns ?? (isVerticalLayout
     ? 1
     : isHorizontalLayout
       ? visibleStats.length
       : isExportVariant || isNarrowLayout
         ? Math.min(visibleStats.length, 2)
-        : Math.min(visibleStats.length, 4);
+        : Math.min(visibleStats.length, 4));
 
   const trackCount = segmentTimings.filter((s) => s.type === 'track').length;
   const transportCount = segmentTimings.filter((s) => s.type === 'transport').length;
@@ -177,7 +180,11 @@ export function StatsOverlay({ compact = false, layout = 'default', variant = 'd
         className={`grid w-max ${isExportVariant || isNarrowLayout ? 'gap-x-1.5 gap-y-1.5 mb-0' : 'gap-2 mb-0'}`}
         style={{ gridTemplateColumns: `repeat(${cols}, minmax(max-content, 1fr))` }}
       >
-        {visibleStats.map((stat) => (
+        {visibleStats.map((stat, index) => {
+          const remainder = visibleStats.length % cols;
+          const firstIncompleteRowIndex = visibleStats.length - remainder;
+          const centerOffset = remainder > 0 ? Math.ceil((cols - remainder) / 2) : 0;
+          return (
           <StatItem
             key={stat.id}
             statId={stat.id}
@@ -187,8 +194,10 @@ export function StatsOverlay({ compact = false, layout = 'default', variant = 'd
             reserve={reserveValues[stat.id]}
             compact={isNarrowLayout}
             exportCompact={isExportVariant}
+            gridColumnStart={index === firstIncompleteRowIndex && remainder > 0 ? centerOffset + 1 : undefined}
           />
-        ))}
+          );
+        })}
       </div>
 
       {!isExportVariant && segmentTimings.length > 1 && (
@@ -212,11 +221,15 @@ interface StatItemProps {
   reserve?: string;
   compact?: boolean;
   exportCompact?: boolean;
+  gridColumnStart?: number;
 }
 
-function StatItem({ statId, icon, label, value, reserve, compact = false, exportCompact = false }: StatItemProps) {
+function StatItem({ statId, icon, label, value, reserve, compact = false, exportCompact = false, gridColumnStart }: StatItemProps) {
   return (
-    <div className={`min-w-max text-center ${exportCompact ? 'px-0.5 py-0.5' : compact ? 'px-1 py-0.5' : 'px-1 py-0.5'}`}>
+    <div
+      className={`min-w-max text-center ${exportCompact ? 'px-0.5 py-0.5' : compact ? 'px-1 py-0.5' : 'px-1 py-0.5'}`}
+      style={gridColumnStart ? { gridColumnStart } : undefined}
+    >
       <div className={`flex items-center justify-center min-w-0 ${
         exportCompact ? 'gap-1 mb-0.5' : compact ? 'gap-1 mb-1' : 'gap-1.5 mb-1.5'
       }`}>

--- a/app/src/components/stats/StatsOverlay.tsx
+++ b/app/src/components/stats/StatsOverlay.tsx
@@ -17,7 +17,7 @@ import {
 
 interface StatsOverlayProps {
   compact?: boolean;
-  layout?: 'default' | 'narrow';
+  layout?: 'default' | 'narrow' | 'horizontal' | 'vertical';
   variant?: 'default' | 'export';
 }
 
@@ -28,6 +28,8 @@ export function StatsOverlay({ compact = false, layout = 'default', variant = 'd
   const playback = useAppStore((state) => state.playback);
   const settings = useAppStore((state) => state.settings);
   const isNarrowLayout = compact || layout === 'narrow';
+  const isHorizontalLayout = layout === 'horizontal';
+  const isVerticalLayout = layout === 'vertical';
   const isExportVariant = variant === 'export';
 
   const {
@@ -150,9 +152,13 @@ export function StatsOverlay({ compact = false, layout = 'default', variant = 'd
 
   if (visibleStats.length === 0) return null;
 
-  const cols = isExportVariant || isNarrowLayout
-    ? Math.min(visibleStats.length, 2)
-    : Math.min(visibleStats.length, 4);
+  const cols = isVerticalLayout
+    ? 1
+    : isHorizontalLayout
+      ? visibleStats.length
+      : isExportVariant || isNarrowLayout
+        ? Math.min(visibleStats.length, 2)
+        : Math.min(visibleStats.length, 4);
 
   const trackCount = segmentTimings.filter((s) => s.type === 'track').length;
   const transportCount = segmentTimings.filter((s) => s.type === 'transport').length;

--- a/app/src/components/stats/StatsOverlay.tsx
+++ b/app/src/components/stats/StatsOverlay.tsx
@@ -174,6 +174,7 @@ export function StatsOverlay({ compact = false, layout = 'default', variant = 'd
         {visibleStats.map((stat) => (
           <StatItem
             key={stat.id}
+            statId={stat.id}
             icon={stat.icon}
             label={stat.label}
             value={stat.value!}
@@ -197,6 +198,7 @@ export function StatsOverlay({ compact = false, layout = 'default', variant = 'd
 }
 
 interface StatItemProps {
+  statId: StatId;
   icon: React.ReactNode;
   label: string;
   value: string;
@@ -206,7 +208,7 @@ interface StatItemProps {
   exportCompact?: boolean;
 }
 
-function StatItem({ icon, label, value, reserve, compact = false, exportCompact = false }: StatItemProps) {
+function StatItem({ statId, icon, label, value, reserve, compact = false, exportCompact = false }: StatItemProps) {
   return (
     <div className={`min-w-max text-center ${exportCompact ? 'px-0.5 py-0.5' : compact ? 'px-1 py-0.5' : 'px-1 py-0.5'}`}>
       <div className={`flex items-center justify-center min-w-0 ${
@@ -237,7 +239,12 @@ function StatItem({ icon, label, value, reserve, compact = false, exportCompact 
             {reserve}
           </span>
         )}
-        <span className="col-start-1 row-start-1">{value}</span>
+        <span
+          className="col-start-1 row-start-1"
+          data-export-stat-value={statId}
+        >
+          {value}
+        </span>
       </div>
     </div>
   );

--- a/app/src/i18n/locales/ca.ts
+++ b/app/src/i18n/locales/ca.ts
@@ -337,6 +337,7 @@ export const ca = {
     ghostTrailOpacityHint: 'Posa 0 per amagar la previsualització completa de la ruta i revelar-la només a mesura que avança la reproducció.',
     statsTitle: 'Estadístiques',
     statsHint: 'Arrossega el quadre d\'estadístiques al mapa per reposicionar-lo.',
+    statsSize: 'Mida de les estadístiques',
     paceMode: 'Mode ritme',
     paceModeCumulative: 'Global',
     paceModePerKm: 'Per km',

--- a/app/src/i18n/locales/ca.ts
+++ b/app/src/i18n/locales/ca.ts
@@ -144,7 +144,7 @@ export const ca = {
     },
     cameraStability: {
       title: 'Estabilitat de la càmera',
-      stable: 'Estable',
+      stable: 'Cinemàtica',
       reactive: 'Reactiva',
     },
     units: 'Unitats',

--- a/app/src/i18n/locales/ca.ts
+++ b/app/src/i18n/locales/ca.ts
@@ -337,7 +337,6 @@ export const ca = {
     ghostTrailOpacityHint: 'Posa 0 per amagar la previsualització completa de la ruta i revelar-la només a mesura que avança la reproducció.',
     statsTitle: 'Estadístiques',
     statsHint: 'Arrossega el quadre d\'estadístiques al mapa per reposicionar-lo.',
-    statsSize: 'Mida de les estadístiques',
     paceMode: 'Mode ritme',
     paceModeCumulative: 'Global',
     paceModePerKm: 'Per km',

--- a/app/src/i18n/locales/de.ts
+++ b/app/src/i18n/locales/de.ts
@@ -144,7 +144,7 @@ export const de = {
     },
     cameraStability: {
       title: 'Kamerastabilität',
-      stable: 'Stabil',
+      stable: 'Filmisch',
       reactive: 'Reaktiv',
     },
     units: 'Einheiten',

--- a/app/src/i18n/locales/de.ts
+++ b/app/src/i18n/locales/de.ts
@@ -337,6 +337,7 @@ export const de = {
     ghostTrailOpacityHint: 'Legen Sie den Wert auf 0 fest, um die vollständige Routenvorschau auszublenden und sie erst bei fortschreitender Wiedergabe anzuzeigen.',
     statsTitle: 'Statistiken',
     statsHint: 'Ziehen Sie das Statistikfeld auf der Karte, um es neu zu positionieren.',
+    statsSize: 'Statistikgröße',
     paceMode: 'Tempomodus',
     paceModeCumulative: 'Gesamt',
     paceModePerKm: 'Pro km',

--- a/app/src/i18n/locales/de.ts
+++ b/app/src/i18n/locales/de.ts
@@ -337,7 +337,6 @@ export const de = {
     ghostTrailOpacityHint: 'Legen Sie den Wert auf 0 fest, um die vollständige Routenvorschau auszublenden und sie erst bei fortschreitender Wiedergabe anzuzeigen.',
     statsTitle: 'Statistiken',
     statsHint: 'Ziehen Sie das Statistikfeld auf der Karte, um es neu zu positionieren.',
-    statsSize: 'Statistikgröße',
     paceMode: 'Tempomodus',
     paceModeCumulative: 'Gesamt',
     paceModePerKm: 'Pro km',

--- a/app/src/i18n/locales/en.ts
+++ b/app/src/i18n/locales/en.ts
@@ -337,7 +337,6 @@ export const en = {
     ghostTrailOpacityHint: 'Set to 0 to hide the full route preview and reveal it only as playback progresses.',
     statsTitle: 'Stats',
     statsHint: 'Drag the stats box on the map to reposition it.',
-    statsSize: 'Stats size',
     paceMode: 'Pace mode',
     paceModeCumulative: 'Overall',
     paceModePerKm: 'Per km',

--- a/app/src/i18n/locales/en.ts
+++ b/app/src/i18n/locales/en.ts
@@ -144,7 +144,7 @@ export const en = {
     },
     cameraStability: {
       title: 'Camera Stability',
-      stable: 'Stable',
+      stable: 'Cinematic',
       reactive: 'Reactive',
     },
     units: 'Units',

--- a/app/src/i18n/locales/en.ts
+++ b/app/src/i18n/locales/en.ts
@@ -337,6 +337,7 @@ export const en = {
     ghostTrailOpacityHint: 'Set to 0 to hide the full route preview and reveal it only as playback progresses.',
     statsTitle: 'Stats',
     statsHint: 'Drag the stats box on the map to reposition it.',
+    statsSize: 'Stats size',
     paceMode: 'Pace mode',
     paceModeCumulative: 'Overall',
     paceModePerKm: 'Per km',

--- a/app/src/i18n/locales/es.ts
+++ b/app/src/i18n/locales/es.ts
@@ -144,7 +144,7 @@ export const es = {
     },
     cameraStability: {
       title: 'Estabilidad de cámara',
-      stable: 'Estable',
+      stable: 'Cinemática',
       reactive: 'Reactiva',
     },
     units: 'Unidades',

--- a/app/src/i18n/locales/es.ts
+++ b/app/src/i18n/locales/es.ts
@@ -337,7 +337,6 @@ export const es = {
     ghostTrailOpacityHint: 'Pon 0 para ocultar la vista previa completa de la ruta y revelarla solo a medida que avanza la reproducción.',
     statsTitle: 'Estadísticas',
     statsHint: 'Arrastra el cuadro de estadísticas en el mapa para reposicionarlo.',
-    statsSize: 'Tamaño de estadísticas',
     paceMode: 'Modo ritmo',
     paceModeCumulative: 'Global',
     paceModePerKm: 'Por km',

--- a/app/src/i18n/locales/es.ts
+++ b/app/src/i18n/locales/es.ts
@@ -337,6 +337,7 @@ export const es = {
     ghostTrailOpacityHint: 'Pon 0 para ocultar la vista previa completa de la ruta y revelarla solo a medida que avanza la reproducción.',
     statsTitle: 'Estadísticas',
     statsHint: 'Arrastra el cuadro de estadísticas en el mapa para reposicionarlo.',
+    statsSize: 'Tamaño de estadísticas',
     paceMode: 'Modo ritmo',
     paceModeCumulative: 'Global',
     paceModePerKm: 'Por km',

--- a/app/src/i18n/locales/fr.ts
+++ b/app/src/i18n/locales/fr.ts
@@ -144,7 +144,7 @@ export const fr = {
     },
     cameraStability: {
       title: 'Stabilité de la caméra',
-      stable: 'Stable',
+      stable: 'Cinématique',
       reactive: 'Réactive',
     },
     units: 'Unités',

--- a/app/src/i18n/locales/fr.ts
+++ b/app/src/i18n/locales/fr.ts
@@ -337,7 +337,6 @@ export const fr = {
     ghostTrailOpacityHint: 'Mettre à 0 pour masquer l\'aperçu complet du tracé et ne le révéler qu\'au fur et à mesure de la lecture.',
     statsTitle: 'Statistiques',
     statsHint: 'Glissez la boîte de stats sur la carte pour la repositionner.',
-    statsSize: 'Taille des statistiques',
     paceMode: 'Mode allure',
     paceModeCumulative: 'Globale',
     paceModePerKm: 'Par km',

--- a/app/src/i18n/locales/fr.ts
+++ b/app/src/i18n/locales/fr.ts
@@ -337,6 +337,7 @@ export const fr = {
     ghostTrailOpacityHint: 'Mettre à 0 pour masquer l\'aperçu complet du tracé et ne le révéler qu\'au fur et à mesure de la lecture.',
     statsTitle: 'Statistiques',
     statsHint: 'Glissez la boîte de stats sur la carte pour la repositionner.',
+    statsSize: 'Taille des statistiques',
     paceMode: 'Mode allure',
     paceModeCumulative: 'Globale',
     paceModePerKm: 'Par km',

--- a/app/src/store/defaults.ts
+++ b/app/src/store/defaults.ts
@@ -56,6 +56,7 @@ export function createDefaultSettings(): AppSettings {
     visibleStats: ['duration', 'distance', 'pace', 'elevation'] as import('@/types').StatId[],
     journeyStatsMode: 'cumulative',
     statsPosition: null,
+    statsScale: 1,
     paceMode: 'per-km' as const,
     showElevationProfile: true,
   };

--- a/app/src/store/defaults.ts
+++ b/app/src/store/defaults.ts
@@ -58,6 +58,7 @@ export function createDefaultSettings(): AppSettings {
     statsPosition: null,
     statsScale: 1,
     statsLayout: 'auto',
+    statsColumns: null,
     paceMode: 'per-km' as const,
     showElevationProfile: true,
   };

--- a/app/src/store/defaults.ts
+++ b/app/src/store/defaults.ts
@@ -57,6 +57,7 @@ export function createDefaultSettings(): AppSettings {
     journeyStatsMode: 'cumulative',
     statsPosition: null,
     statsScale: 1,
+    statsLayout: 'auto',
     paceMode: 'per-km' as const,
     showElevationProfile: true,
   };

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -305,6 +305,7 @@ export interface AppSettings {
   statsPosition: { x: number; y: number } | null;
   statsScale: number;
   statsLayout: 'auto' | 'horizontal' | 'vertical';
+  statsColumns: number | null;
   paceMode: 'cumulative' | 'per-km';
   showElevationProfile: boolean;
 }

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -303,6 +303,7 @@ export interface AppSettings {
   visibleStats: StatId[];
   journeyStatsMode: JourneyStatsMode;
   statsPosition: { x: number; y: number } | null;
+  statsScale: number;
   paceMode: 'cumulative' | 'per-km';
   showElevationProfile: boolean;
 }

--- a/app/src/types/index.ts
+++ b/app/src/types/index.ts
@@ -304,6 +304,7 @@ export interface AppSettings {
   journeyStatsMode: JourneyStatsMode;
   statsPosition: { x: number; y: number } | null;
   statsScale: number;
+  statsLayout: 'auto' | 'horizontal' | 'vertical';
   paceMode: 'cumulative' | 'per-km';
   showElevationProfile: boolean;
 }

--- a/app/src/utils/projectFile/hydrateProject.test.ts
+++ b/app/src/utils/projectFile/hydrateProject.test.ts
@@ -157,10 +157,10 @@ describe('hydrateProject', () => {
     expect(targetStore.getState().playback.routeTimingMode).toBe('recorded');
   });
 
-  it('persists stats scale and defaults legacy projects to 1x', async () => {
+  it('persists stats presentation and defaults legacy projects to the automatic 1x layout', async () => {
     const sourceStore = createAppStore();
     sourceStore.getState().addTrack(parseGPX(sampleGpx, 'ridge-loop.gpx'));
-    sourceStore.getState().setSettings({ statsScale: 1.6 });
+    sourceStore.getState().setSettings({ statsScale: 1.6, statsLayout: 'vertical' });
 
     const blob = await buildReplayArchive(sourceStore.getState());
     const parsed = await parseReplayArchive(new File([blob], 'project.replay'));
@@ -168,10 +168,13 @@ describe('hydrateProject', () => {
     const scaledStore = createAppStore();
     hydrateProject(parsed, scaledStore.getState());
     expect(scaledStore.getState().settings.statsScale).toBe(1.6);
+    expect(scaledStore.getState().settings.statsLayout).toBe('vertical');
 
     delete (parsed.project.settings as Partial<typeof parsed.project.settings>).statsScale;
+    delete (parsed.project.settings as Partial<typeof parsed.project.settings>).statsLayout;
     const legacyStore = createAppStore();
     hydrateProject(parsed, legacyStore.getState());
     expect(legacyStore.getState().settings.statsScale).toBe(1);
+    expect(legacyStore.getState().settings.statsLayout).toBe('auto');
   });
 });

--- a/app/src/utils/projectFile/hydrateProject.test.ts
+++ b/app/src/utils/projectFile/hydrateProject.test.ts
@@ -156,4 +156,22 @@ describe('hydrateProject', () => {
 
     expect(targetStore.getState().playback.routeTimingMode).toBe('recorded');
   });
+
+  it('persists stats scale and defaults legacy projects to 1x', async () => {
+    const sourceStore = createAppStore();
+    sourceStore.getState().addTrack(parseGPX(sampleGpx, 'ridge-loop.gpx'));
+    sourceStore.getState().setSettings({ statsScale: 1.6 });
+
+    const blob = await buildReplayArchive(sourceStore.getState());
+    const parsed = await parseReplayArchive(new File([blob], 'project.replay'));
+
+    const scaledStore = createAppStore();
+    hydrateProject(parsed, scaledStore.getState());
+    expect(scaledStore.getState().settings.statsScale).toBe(1.6);
+
+    delete (parsed.project.settings as Partial<typeof parsed.project.settings>).statsScale;
+    const legacyStore = createAppStore();
+    hydrateProject(parsed, legacyStore.getState());
+    expect(legacyStore.getState().settings.statsScale).toBe(1);
+  });
 });

--- a/app/src/utils/projectFile/hydrateProject.test.ts
+++ b/app/src/utils/projectFile/hydrateProject.test.ts
@@ -160,7 +160,7 @@ describe('hydrateProject', () => {
   it('persists stats presentation and defaults legacy projects to the automatic 1x layout', async () => {
     const sourceStore = createAppStore();
     sourceStore.getState().addTrack(parseGPX(sampleGpx, 'ridge-loop.gpx'));
-    sourceStore.getState().setSettings({ statsScale: 1.6, statsLayout: 'vertical' });
+    sourceStore.getState().setSettings({ statsScale: 1.6, statsLayout: 'vertical', statsColumns: 2 });
 
     const blob = await buildReplayArchive(sourceStore.getState());
     const parsed = await parseReplayArchive(new File([blob], 'project.replay'));
@@ -169,12 +169,15 @@ describe('hydrateProject', () => {
     hydrateProject(parsed, scaledStore.getState());
     expect(scaledStore.getState().settings.statsScale).toBe(1.6);
     expect(scaledStore.getState().settings.statsLayout).toBe('vertical');
+    expect(scaledStore.getState().settings.statsColumns).toBe(2);
 
     delete (parsed.project.settings as Partial<typeof parsed.project.settings>).statsScale;
     delete (parsed.project.settings as Partial<typeof parsed.project.settings>).statsLayout;
+    delete (parsed.project.settings as Partial<typeof parsed.project.settings>).statsColumns;
     const legacyStore = createAppStore();
     hydrateProject(parsed, legacyStore.getState());
     expect(legacyStore.getState().settings.statsScale).toBe(1);
     expect(legacyStore.getState().settings.statsLayout).toBe('auto');
+    expect(legacyStore.getState().settings.statsColumns).toBeNull();
   });
 });

--- a/app/src/utils/projectFile/hydrateProject.ts
+++ b/app/src/utils/projectFile/hydrateProject.ts
@@ -1,6 +1,6 @@
 import type { AppState } from '@/store/storeTypes';
 import { parseGPX } from '@/utils/gpxParser';
-import { createDefaultCameraSettings, createDefaultPlayback } from '@/store/defaults';
+import { createDefaultCameraSettings, createDefaultPlayback, createDefaultSettings } from '@/store/defaults';
 import type { ComparisonTrack, PictureAnnotation, VideoAnnotation } from '@/types';
 import type { ParsedProject, SerializedPicture, SerializedVideo } from './types';
 
@@ -90,7 +90,9 @@ export function hydrateProject(parsed: ParsedProject, store: AppState): void {
     // defaults rather than `store.playback`, since `store` was captured
     // before `store.reset()` above and still holds the pre-reset value.
     playback: { ...createDefaultPlayback(), routeTimingMode: project.routeTimingMode ?? 'recorded' },
-    settings: project.settings,
+    // Merge defaults so projects saved before newer presentation controls
+    // (such as statsScale) retain the original 1x appearance.
+    settings: { ...createDefaultSettings(), ...project.settings },
     // Older saved projects predate cameraStability; backfill it so an
     // undefined value doesn't turn the camera smoothing math into NaN.
     cameraSettings: { ...createDefaultCameraSettings(), ...project.cameraSettings },


### PR DESCRIPTION
## Summary

- remove the homepage placeholder `VideoObject` that Google Search Console flags for missing `thumbnailUrl` and `uploadDate`
- validate every generated `VideoObject` has Google’s required `name`, `thumbnailUrl`, and `uploadDate` fields
- make the maximum-stability camera setting a fully cinematic glide by applying stability to center movement as well as bearing, pitch, and zoom
- stabilize terrain-driven zoom targets in cinematic mode to prevent repeated, sudden zoom reversals
- animate the elevation profile smoothly at the live/export frame rate without expensive full-overlay recaptures
- rename the stable endpoint to Cinematic in all supported locales

## Camera behavior

The center curve is intentionally nonlinear on the cinematic half. This keeps the familiar behavior near the default while giving the far-left endpoint a much smoother, floating review.

Cinematic zoom now uses a two-stage rig: a target filter absorbs terrain noise and holds changes inside a 0.3 zoom-level hysteresis band at maximum stability, then the camera eases toward the stabilized target. Opening the frame uses a 1.2 s response; returning to a tight shot uses 5 s, preventing rapid zoom breathing. Explicit distance changes remain immediate.

## Elevation performance

Live playback no longer rebuilds a growing SVG path by scanning every elevation sample on every frame. The profile is static and a lightweight clip rectangle reveals progress; the current elevation is found with binary-search interpolation.

Export keeps the static profile in the cached DOM overlay, but draws the moving fill and label directly with native canvas primitives on every encoded frame. This removes the visible 12fps stepping without increasing expensive `html2canvas` captures to 30/60fps. SVG paths are cached as `Path2D` objects.

## Verification

- `npm --prefix app run test:run` — 40 files / 176 tests passed
- `npm --prefix app run build` — production build, prerender, and SEO validation passed
- `npm --prefix app run lint` — no errors; one existing hook dependency warning in `useVideoExportRecorder.ts`
