### PR TITLE
Add Bresca credit link in info panel and help pages

### DIFF
--- a/app/src/components/info/InfoPanel.tsx
+++ b/app/src/components/info/InfoPanel.tsx
@@ -1,4 +1,4 @@
-import { X, Github, Instagram, MessageSquare, Heart, ExternalLink, Shield, FileText, BookOpen, Download, Sparkles } from 'lucide-react';
+import { X, Github, Instagram, MessageSquare, Heart, ExternalLink, Shield, FileText, BookOpen, Download, Sparkles, Building2 } from 'lucide-react';
 import { useI18n } from '@/i18n/useI18n';
 import { trackEvent } from '@/utils/analytics';
 
@@ -133,6 +133,12 @@ export function InfoPanel({ onClose }: InfoPanelProps) {
               href="https://www.instagram.com/trailreplay/"
               icon={<Instagram className="w-4 h-4" />}
               label={t('info.instagram')}
+              external
+            />
+            <InfoLink
+              href="https://bresca.ai"
+              icon={<Building2 className="w-4 h-4" />}
+              label={t('info.builtBy')}
               external
             />
           </div>

--- a/app/src/help/HelpLayout.tsx
+++ b/app/src/help/HelpLayout.tsx
@@ -112,6 +112,17 @@ export function HelpLayout({ eyebrow, title, description, headerActions = [], ch
             <a href="/running-route-animation" className="font-semibold text-[var(--trail-orange)] hover:underline">Running animation</a>
           </div>
         </section>
+
+        <footer className="border-t border-[var(--evergreen)]/12 pt-6 text-xs text-[var(--evergreen-60)]">
+          <a
+            href="https://bresca.ai"
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-semibold hover:text-[var(--trail-orange)] hover:underline"
+          >
+            {t('help.common.builtBy')}
+          </a>
+        </footer>
       </main>
     </div>
   );

--- a/app/src/i18n/locales/ca.ts
+++ b/app/src/i18n/locales/ca.ts
@@ -167,6 +167,7 @@ export const ca = {
     connect: 'Connecta',
     github: 'Veure a GitHub',
     instagram: 'Segueix a Instagram',
+    builtBy: 'Creat per Bresca',
     support: 'Dona suport al projecte',
     donateTitle: 'Convida’m a un cafè',
     donateSubtitle: 'Ajuda a mantenir TrailReplay gratuït',
@@ -538,6 +539,7 @@ export const ca = {
   help: {
     common: {
       backToApp: 'Tornar a l’app',
+      builtBy: 'Creat per Bresca',
       openApp: 'Obrir TrailReplay',
       github: 'GitHub',
       builtForLabel: 'Pensat per a',

--- a/app/src/i18n/locales/de.ts
+++ b/app/src/i18n/locales/de.ts
@@ -167,6 +167,7 @@ export const de = {
     connect: 'Verbinden',
     github: 'Auf GitHub ansehen',
     instagram: 'Folgen Sie auf Instagram',
+    builtBy: 'Erstellt von Bresca',
     support: 'Unterstützen Sie das Projekt',
     donateTitle: 'Kauf mir einen Kaffee',
     donateSubtitle: 'Helfen Sie mit, TrailReplay kostenlos zu halten',
@@ -538,6 +539,7 @@ export const de = {
   help: {
     common: {
       backToApp: 'Zurück zur App',
+      builtBy: 'Erstellt von Bresca',
       openApp: 'Öffnen Sie TrailReplay',
       github: 'GitHub',
       builtForLabel: 'Gebaut für',

--- a/app/src/i18n/locales/en.ts
+++ b/app/src/i18n/locales/en.ts
@@ -167,6 +167,7 @@ export const en = {
     connect: 'Connect',
     github: 'View on GitHub',
     instagram: 'Follow on Instagram',
+    builtBy: 'Built by Bresca',
     support: 'Support the Project',
     donateTitle: 'Buy me a coffee',
     donateSubtitle: 'Help keep TrailReplay free',
@@ -538,6 +539,7 @@ export const en = {
   help: {
     common: {
       backToApp: 'Back to app',
+      builtBy: 'Built by Bresca',
       openApp: 'Open TrailReplay',
       github: 'GitHub',
       builtForLabel: 'Built for',

--- a/app/src/i18n/locales/es.ts
+++ b/app/src/i18n/locales/es.ts
@@ -167,6 +167,7 @@ export const es = {
     connect: 'Conectar',
     github: 'Ver en GitHub',
     instagram: 'Seguir en Instagram',
+    builtBy: 'Creado por Bresca',
     support: 'Apoya el proyecto',
     donateTitle: 'Invítame a un café',
     donateSubtitle: 'Ayuda a mantener TrailReplay gratis',
@@ -538,6 +539,7 @@ export const es = {
   help: {
     common: {
       backToApp: 'Volver a la app',
+      builtBy: 'Creado por Bresca',
       openApp: 'Abrir TrailReplay',
       github: 'GitHub',
       builtForLabel: 'Pensado para',

--- a/app/src/i18n/locales/fr.ts
+++ b/app/src/i18n/locales/fr.ts
@@ -167,6 +167,7 @@ export const fr = {
     connect: 'Suivre le projet',
     github: 'Voir sur GitHub',
     instagram: 'Suivre sur Instagram',
+    builtBy: 'Créé par Bresca',
     support: 'Soutenir le projet',
     donateTitle: 'Offrez-moi un café',
     donateSubtitle: 'Aidez à maintenir TrailReplay gratuit',
@@ -538,6 +539,7 @@ export const fr = {
   help: {
   common: {
     backToApp: 'Retour à l\'application',
+    builtBy: 'Créé par Bresca',
     openApp: 'Ouvrir TrailReplay',
     github: 'GitHub',
     builtForLabel: 'Conçu pour',


### PR DESCRIPTION
## Summary
- Adds a "Built by Bresca" link to the app's Info panel "Connect" section, next to GitHub/Instagram
- Adds the same credit to the footer of the shared help-page layout (tutorial + GPX download guide)
- Translated across all 5 locales (en, es, ca, de, fr)

## Test plan
- [x] `npm run build` passes (typecheck + build + asset size check)
- [x] `npm run lint` passes (pre-existing unrelated warning only)
- [x] `npm --prefix app run test:run` — all 179 tests pass, including i18n key-parity test

🤖 Generated with [Claude Code](https://claude.com/claude-code)