### PR TITLE
Fix elevation reset between replay routes

### DIFF
--- a/app/src/components/stats/liveStats.test.ts
+++ b/app/src/components/stats/liveStats.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest';
 import type { GPXPoint, GPXTrack, TrackSegment } from '@/types';
+import { createDefaultSettings } from '@/store/defaults';
 import { buildComputedJourney } from '@/utils/journeyUtils';
 import { calculateCurrentLiveStats, elapsedTrackTime } from './liveStats';
 
@@ -45,6 +46,35 @@ function track(id: string, elevations: [number, number, number], hasTime = true)
 }
 
 describe('calculateCurrentLiveStats', () => {
+  it('starts elevation gain at zero when the second route begins with default settings', () => {
+    const tracks = [track('first', [100, 150, 200]), track('second', [300, 320, 310])];
+    const segments: TrackSegment[] = tracks.map((entry) => ({
+      id: `segment-${entry.id}`,
+      type: 'track',
+      trackId: entry.id,
+      duration: 1000,
+    }));
+    const computedJourney = buildComputedJourney(segments, tracks)!;
+
+    const stats = calculateCurrentLiveStats({
+      activeTrack: tracks[0],
+      computedJourney,
+      currentPosition: {
+        ...tracks[1].points[0],
+        segmentIndex: 1,
+        segmentType: 'track',
+        trackId: 'second',
+      },
+      playbackProgress: 0.5001,
+      restartPerTrack: createDefaultSettings().journeyStatsMode === 'per-track',
+      segmentTimings: computedJourney.segmentTimings,
+      totalDistance: computedJourney.totalDistance,
+      tracks,
+    });
+
+    expect(stats.elevationGain).toBe(0);
+  });
+
   it('can restart distance, duration, pace basis, and elevation for each track', () => {
     const tracks = [track('first', [100, 120, 140]), track('second', [50, 70, 60])];
     const segments: TrackSegment[] = tracks.map((entry) => ({

--- a/app/src/components/stats/liveStats.test.ts
+++ b/app/src/components/stats/liveStats.test.ts
@@ -179,4 +179,66 @@ describe('calculateCurrentLiveStats', () => {
     const untimed = track('solo', [100, 120, 140], false);
     expect(elapsedTrackTime([], [], untimed, 0.5, 30)).toBe(15);
   });
+
+  /**
+   * Elevation used to be counted from the duration ratios while distance came
+   * from the marker. Under Constant Pace the marker advances by distance, so on
+   * legs whose durations are not proportional to their lengths the two told
+   * different stories: distance still reading leg 1 while elevation had already
+   * added the whole of it, and elevation a thousand metres up by the time
+   * distance reset to zero.
+   */
+  it('keeps elevation on the same leg as distance when legs are equal in time but not in length', () => {
+    // Three equal 30s legs of very different lengths, which is what dropping
+    // three GPX files gives you.
+    const long = track('long', [0, 500, 1000]);
+    const short = track('short', [0, 100, 200]);
+    // Stretch the first leg so distance and duration cannot agree.
+    long.points = long.points.map((point, index) => ({ ...point, distance: index * 10_000 }));
+    long.totalDistance = 20_000;
+    short.points = short.points.map((point, index) => ({ ...point, distance: index * 1_000 }));
+    short.totalDistance = 2_000;
+
+    const tracks = [long, short];
+    const segments: TrackSegment[] = tracks.map((entry) => ({
+      id: `segment-${entry.id}`, type: 'track', trackId: entry.id, duration: 30_000,
+    }));
+    const computedJourney = buildComputedJourney(segments, tracks)!;
+
+    const statsAt = (segmentIndex: number, distanceIntoLeg: number, progress: number) => {
+      const source = tracks[segmentIndex];
+      const point = source.points.reduce((best, candidate) => (
+        candidate.distance <= distanceIntoLeg ? candidate : best), source.points[0]);
+      return calculateCurrentLiveStats({
+        activeTrack: tracks[0],
+        computedJourney,
+        currentPosition: {
+          ...point,
+          distance: distanceIntoLeg,
+          segmentIndex,
+          segmentType: 'track',
+          trackId: source.id,
+        },
+        playbackProgress: progress,
+        restartPerTrack: true,
+        segmentTimings: computedJourney.segmentTimings,
+        totalDistance: computedJourney.totalDistance,
+        tracks,
+      });
+    };
+
+    // Progress says leg 2; the marker is still most of the way through leg 1.
+    // Elevation must follow the marker, not the clock.
+    const stillOnLegOne = statsAt(0, 15_000, 0.4);
+    expect(stillOnLegOne.distance).toBe(15_000);
+    // Leg 1 climbs 1000 m in total and leg 2 another 200 m. Counting from the
+    // clock would have added all of leg 1 plus part of leg 2.
+    expect(stillOnLegOne.elevationGain).toBeGreaterThan(0);
+    expect(stillOnLegOne.elevationGain).toBeLessThanOrEqual(1000);
+
+    // The moment the marker does cross, both restart together.
+    const justOntoLegTwo = statsAt(1, 0, 0.5);
+    expect(justOntoLegTwo.distance).toBe(0);
+    expect(justOntoLegTwo.elevationGain).toBe(0);
+  });
 });

--- a/app/src/components/stats/liveStats.ts
+++ b/app/src/components/stats/liveStats.ts
@@ -43,6 +43,21 @@ export function calculateElevationGain(
   return elevationGain;
 }
 
+/**
+ * The last point at or before `distance` along a leg.
+ *
+ * Coordinates carry the distance from their own track's start, so this is the
+ * marker's position expressed as an index into the leg — the same anchor the
+ * distance stat uses, which is what keeps the two from drifting apart.
+ */
+function pointIndexAtDistance(points: Array<{ distance: number }>, distance: number): number {
+  if (points.length === 0) return 0;
+  for (let index = 0; index < points.length; index += 1) {
+    if (points[index].distance > distance) return Math.max(0, index - 1);
+  }
+  return points.length - 1;
+}
+
 function localProgressFor(timing: SegmentTiming, playbackProgress: number): number {
   const span = timing.progressEndRatio - timing.progressStartRatio;
   if (span <= 0) return 0;
@@ -193,18 +208,32 @@ export function calculateCurrentLiveStats({
 
   let elevationGain = 0;
   if (computedJourney && segmentTimings.length > 0) {
+    // Which leg we are on, and how far into it, comes from the marker rather
+    // than from the progress ratios.
+    //
+    // The ratios are shares of the video's duration. Under Constant Pace the
+    // marker advances by distance instead, so on legs whose durations are not
+    // proportional to their lengths the two disagree: with three equal 30 s legs
+    // of 32/24/14 km, progress 0.4 is a third of the way into leg 2 by duration
+    // and still 28 km into leg 1 by distance. Elevation counted from the ratios
+    // therefore added a whole leg's climb while the distance beside it still
+    // read leg 1 — and once distance did reset to zero, elevation was already a
+    // thousand metres into the leg.
     for (const timing of segmentTimings) {
       if (timing.type !== 'track') continue;
       const segment = computedJourney.coordinates.slice(timing.startCoordIndex, timing.endCoordIndex + 1);
-      if (playbackProgress >= timing.progressEndRatio) {
-        if (!resetThisSegment || timing.segmentIndex === currentPosition.segmentIndex) {
-          elevationGain += calculateElevationGain(segment, segment.length - 1);
-        }
-      } else if (playbackProgress > timing.progressStartRatio) {
-        const upToIndex = Math.floor(localProgressFor(timing, playbackProgress) * (segment.length - 1));
-        elevationGain += calculateElevationGain(segment, upToIndex);
+
+      if (timing.segmentIndex < currentPosition.segmentIndex) {
+        if (!resetThisSegment) elevationGain += calculateElevationGain(segment, segment.length - 1);
+        continue;
+      }
+
+      if (timing.segmentIndex === currentPosition.segmentIndex) {
+        elevationGain += calculateElevationGain(segment, pointIndexAtDistance(segment, currentPosition.distance ?? 0));
         break;
       }
+
+      break;
     }
   } else if (activeTrack) {
     const targetDistance = activeTrack.totalDistance * playbackProgress;

--- a/app/src/store/createAppStore.test.ts
+++ b/app/src/store/createAppStore.test.ts
@@ -178,7 +178,7 @@ describe('createAppStore', () => {
     expect(state.settings.trailStyle.currentIcon).toBe(DEFAULT_ACTIVITY_ICON);
     expect(state.settings.trailStyle.markerColor).toBe('#56C596');
     expect(state.settings.trailStyle.trackLabel).toBe('Track 1');
-    expect(state.settings.journeyStatsMode).toBe('cumulative');
+    expect(state.settings.journeyStatsMode).toBe('per-track');
     expect(state.settings.trailStyle).not.toBe(initialTrailStyle);
   });
 

--- a/app/src/store/defaults.ts
+++ b/app/src/store/defaults.ts
@@ -55,7 +55,7 @@ export function createDefaultSettings(): AppSettings {
     waybackRelease: null,
     waybackItemURL: null,
     visibleStats: ['duration', 'distance', 'pace', 'elevation'] as import('@/types').StatId[],
-    journeyStatsMode: 'cumulative',
+    journeyStatsMode: 'per-track',
     statsPosition: null,
     statsScale: 1,
     statsLayout: 'auto',


### PR DESCRIPTION
## Summary
- default multi-route replay stats to restart for each track
- prevent the second route elevation gain from inheriting the first route total
- keep Journey Total available as an explicit option
- add a regression test covering the start of route two

## Verification
- `npm test -- --run src/store/createAppStore.test.ts src/components/stats/liveStats.test.ts`
- `npm run lint -- --quiet`
- `npm run build`